### PR TITLE
Partially removed the banned APIs from SCXcore.

### DIFF
--- a/source/code/shared/tools/omi_preexec/omi_preexec.cpp
+++ b/source/code/shared/tools/omi_preexec/omi_preexec.cpp
@@ -119,14 +119,15 @@ static int _createDir(
 
 int main(int argc, char *argv[])
 {
+    char *endptr;
     if (argc != 3)
     {
         std::cerr << "Invalid number of parameters: " << argc << std::endl;
         return 1;
     }
 
-    int uid = atoi( argv[1] );
-    int gid = atoi( argv[2] );
+    int uid = (int) strtol( argv[1], &endptr, 10 );
+    int gid = (int) strtol( argv[2], &endptr, 10 );
 
     // If spawning a non-root process, create subdir for scx log & persist 
     // with new uid as owner, if not already existing, so that we have 

--- a/source/code/shared/tools/scx_ssl_config/scx_ssl_config.cpp
+++ b/source/code/shared/tools/scx_ssl_config/scx_ssl_config.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
                 wcout << L"Enter number of bits." << endl;
                 usage(argv[0], 1);
             }
-            bits = atoi(argv[i]);
+            bits = (int) SCXCoreLib::StrToLong(SCXCoreLib::StrFromUTF8(argv[i]));
             if (0 == bits || 0 != bits%512)
             {
                 wcout << L"Bits must be non-zero dividable by 512." << endl;
@@ -200,17 +200,17 @@ int main(int argc, char *argv[])
                 wcout << "Enter a value for start days." << endl;
                 usage(argv[0], 1);
             }
-            startDays = atoi(argv[i]);
+            startDays = (int) SCXCoreLib::StrToLong(SCXCoreLib::StrFromUTF8(argv[i]));
         }
         else if (enddaysFlag == argv[i])
         {
             // Ensure the value argument exists.
-            if (++i >= argc || atoi(argv[i]) == 0)
+            if (++i >= argc || SCXCoreLib::StrToLong(SCXCoreLib::StrFromUTF8(argv[i])) == 0)
             {
                 wcout << "Enter a non-zero value for end days." << endl;
                 usage(argv[0], 1);
             }
-            endDays = atoi(argv[i]);
+            endDays = (int) SCXCoreLib::StrToLong(SCXCoreLib::StrFromUTF8(argv[i]));
         }
         else if (testFlag == argv[i])
         {
@@ -436,7 +436,7 @@ static int DoGenerate(const wstring & targetPath, int startDays, int endDays,
 
         /*
         ** Finally, make sure the permissions are right:
-        ** The public key gets 444, the private key gets 400
+        ** The pub key gets 444, the priv key gets 400
         */
 
         rc = chmod(sCertFile.c_str(), 00444);

--- a/source/code/shared/tools/scx_ssl_config/scxsslcert.cpp
+++ b/source/code/shared/tools/scx_ssl_config/scxsslcert.cpp
@@ -998,7 +998,7 @@ bool IntegerSuffixComparator::operator()(const SCXCoreLib::SCXFilePath * pa, con
     file_a = pa->Get();
     file_b = pb->Get();
 
-    int sfx_a, sfx_b; // file name suffixes in integer form
+    scxlong sfx_a, sfx_b; // file name suffixes in integer form
     size_t offset_a, offset_b;
 
     // Validation routine verified that the strings contain a '.' before insertion.
@@ -1008,8 +1008,8 @@ bool IntegerSuffixComparator::operator()(const SCXCoreLib::SCXFilePath * pa, con
 
     // Do not handle exceptions, we won't be getting any ... file and directory names are clean 7-bit strings.
     // We also already know that offsets do not point to last char in string ...
-    sfx_a = atoi(SCXCoreLib::StrToMultibyte(file_a.substr(offset_a + 1)).c_str());
-    sfx_b = atoi(SCXCoreLib::StrToMultibyte(file_b.substr(offset_b + 1)).c_str());
+    sfx_a = SCXCoreLib::StrToLong(file_a.substr(offset_a + 1).c_str());
+    sfx_b = SCXCoreLib::StrToLong(file_b.substr(offset_b + 1).c_str());
     return sfx_a > sfx_b;
 }
 


### PR DESCRIPTION
Note that strerror is more involved, and will take some support code
in the PAL to handle that well. That will be done separately.

@MSFTOSSMgmt/ostc-devs 
