### PR TITLE
Remove oss-kits as SCXcore submodule (already added to superprojects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "installer/oss-kits"]
-	path = installer/oss-kits
-	url = git@github.com:Microsoft/SCXcore-osskits.git
-	branch = master

--- a/build/Makefile.kits
+++ b/build/Makefile.kits
@@ -23,10 +23,10 @@ else
     # If this ever changes, we'll likely need a setting in configure script.
     ifneq ($(PF),SunOS)
       ifeq ($(PF_ARCH),x86)
-        OSS_KITS:=$(shell cd $(SCX_BRD)/installer/oss-kits; ls *-oss-test.sh *.i686.sh)
+        OSS_KITS:=$(shell cd $(SCX_BRD)/../opsmgr-kits; ls *-oss-test.sh *.i686.sh)
       else
         ifeq ($(PF_ARCH),x64)
-          OSS_KITS:=$(shell cd $(SCX_BRD)/installer/oss-kits; ls *-oss-test.sh *.x86_64.sh)
+          OSS_KITS:=$(shell cd $(SCX_BRD)/../opsmgr-kits; ls *-oss-test.sh *.x86_64.sh)
         endif
       endif
     endif
@@ -162,7 +162,7 @@ bundle: kit
 
 ifneq ($(OSS_KITS),)
 	# Copy OSS kit files to target directory if Linux or ULINUX
-	cd $(SCX_BRD)/installer/oss-kits; cp $(OSS_KITS) $(INTERMEDIATE_DIR); cd $(INTERMEDIATE_DIR); chmod u+wx $(OSS_KITS);
+	cd $(SCX_BRD)/../opsmgr-kits; cp $(OSS_KITS) $(INTERMEDIATE_DIR); cd $(INTERMEDIATE_DIR); chmod u+wx $(OSS_KITS);
 endif
 
 	# Copy remaining kit files to target directory


### PR DESCRIPTION
(Difficult to manage tips properly; will be tracked by superproject)

This PR will relocate installer/oss-kits to <super-project>/opsmgr-kits. Note that this new super project is already committed to both Build-SCXcore and Build-OMS-Agent-for-Linux projects. Once this is committed, the change will actually take effect.

I'm uncertain how to get the new subproject without a new clone. For simplicity, I'll just suggest that people clone the repo again (trivial with pbuild, just throw on `--clone`), which absolutely works.

@Microsoft/ostc-devs @Microsoft/omsagent-devs 