### PR TITLE
Added tmpdir link for monitoring script storage/execution

### DIFF
--- a/installer/datafiles/AIX.data
+++ b/installer/datafiles/AIX.data
@@ -45,8 +45,10 @@ if [ $OMI_IS_RUNNING -eq 1 ]; then
 fi
 
 %Preuninstall_800
-#include DeleteSoftLinkToSudo
+#include DeleteSoftLinks
+
 DeleteSoftLinkToSudo
+DeleteSoftLinkToTmpDir
 
 %Postuninstall_50
 #if DISABLE_PORT != true

--- a/installer/datafiles/Base_SCXCore.data
+++ b/installer/datafiles/Base_SCXCore.data
@@ -14,6 +14,8 @@ SCX_SSL_CONFIG:          '/opt/microsoft/scx/bin/tools/scxsslconfig'
 SUNOS_PKGSAVE:           ''
 SCX_LOC:                 '/etc/opt/microsoft/scx/conf/sudodir'
 SUDO_DIR:                '/usr/bin'
+TMP_LOC:                 '/etc/opt/microsoft/scx/conf/tmpdir'
+TMP_DIR:                 '/tmp'
 ROOT_GROUP_NAME:         'root'
 SHLIB_EXT:               'so'
 DISABLE_PORT:		 'false'
@@ -115,11 +117,18 @@ else
     OMI_IS_RUNNING=0
 fi
 
-%DeleteSoftLinkToSudo
+%DeleteSoftLinks
 DeleteSoftLinkToSudo() {
     if [ -L ${{SCX_LOC}} ]; then
         LINKED_DIR=`(cd ${{SCX_LOC}} ; pwd -P)`
         [ x${LINKED_DIR} = x${{SUDO_DIR}} ] && rm ${{SCX_LOC}}
+    fi
+}
+
+DeleteSoftLinkToTmpDir() {
+    if [ -L ${{TMP_LOC}} ]; then
+        LINKED_DIR=`(cd ${{TMP_LOC}} ; pwd -P)`
+        [ x${LINKED_DIR} = x${{TMP_DIR}} ] && rm ${{TMP_LOC}}
     fi
 }
 
@@ -176,6 +185,10 @@ UnconfigureScxPAM_dir() {
 #include UnconfigureScxPAM
 CreateSoftLinkToSudo() {
     [ ! -L /etc/opt/microsoft/scx/conf/sudodir ] && ln -s ${{SUDO_DIR}} /etc/opt/microsoft/scx/conf/sudodir || true
+}
+
+CreateSoftLinkToTmpDir() {
+    [ ! -L /etc/opt/microsoft/scx/conf/tmpdir ] && ln -s ${{TMP_DIR}} /etc/opt/microsoft/scx/conf/tmpdir || true
 }
 
 WriteInstallInfo() {
@@ -257,6 +270,7 @@ set -e
 
 %Postinstall_200
 CreateSoftLinkToSudo
+CreateSoftLinkToTmpDir
 
 %Postinstall_300
 WriteInstallInfo

--- a/installer/datafiles/HPUX.data
+++ b/installer/datafiles/HPUX.data
@@ -44,8 +44,10 @@ if [ $OMI_IS_RUNNING -eq 1 ]; then
 fi
 
 %Postuninstall_100
-#include DeleteSoftLinkToSudo
+#include DeleteSoftLinks
+
 DeleteSoftLinkToSudo
+DeleteSoftLinkToTmpDir
 
 %Postuninstall_50
 #if DISABLE_PORT != true

--- a/installer/datafiles/Linux.data
+++ b/installer/datafiles/Linux.data
@@ -54,11 +54,12 @@ fi
 #endif
 
 %Postuninstall_1100
-#include DeleteSoftLinkToSudo
+#include DeleteSoftLinks
 
 ${{OMI_SERVICE}} reload
 
 # If we're called for upgrade, don't do anything
 if ${{PERFORMING_UPGRADE_NOT}}; then
     DeleteSoftLinkToSudo
+    DeleteSoftLinkToTmpDir
 fi

--- a/installer/datafiles/SunOS.data
+++ b/installer/datafiles/SunOS.data
@@ -36,8 +36,10 @@ set +e
 set -e
 
 %Preuninstall_800
-#include DeleteSoftLinkToSudo
+#include DeleteSoftLinks
+
 DeleteSoftLinkToSudo
+DeleteSoftLinkToTmpDir
 
 %Postuninstall_50
 #if DISABLE_PORT != true

--- a/source/code/providers/support/runasprovider.h
+++ b/source/code/providers/support/runasprovider.h
@@ -54,6 +54,11 @@ namespace SCXCore
         {
             m_Configurator = configurator;
         }
+        
+        void SetTemporaryDirectory(std::wstring tmpDir)
+        {
+        	m_defaultTmpDir = tmpDir;
+        }
 
     private:
         void ParseConfiguration() { m_Configurator->Parse(); }
@@ -66,6 +71,7 @@ namespace SCXCore
         SCXCoreLib::SCXHandle<RunAsConfigurator> m_Configurator;
 
         SCXCoreLib::SCXLogHandle m_log;
+        std::wstring m_defaultTmpDir;
         static int ms_loadCount;
     };
 


### PR DESCRIPTION
This is the SCXCore part of DCR to make monitoring script stored and executed from a custom location rather than hardcoded /tmp.

As part of the change a link /etc/opt/microsoft/scx/conf/tmpdir will be created during scx installation. It will point to /tmp by default. System admin can change this to point to any other location on the system.

When RunAs provider's ExecuteScript is called it will read the location and store the script there. 