### PR TITLE
Changes for building local and ULINUX on Debian/Ubuntu:

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -7,6 +7,7 @@
 
 # Set up architecture and Build Root Directory
 # PF (i.e. PlatForm) is either linux, solaris
+SHELL=/bin/bash
 PWD:=$(shell pwd)
 SCX_BRD=$(subst /build,,$(PWD))
 PF_POSIX=true

--- a/build/Makefile.kits
+++ b/build/Makefile.kits
@@ -36,6 +36,11 @@ else
 endif
 
 DISTRO_TYPE = $(PF)
+ifeq ("$(wildcard /usr/bin/dpkg-deb)","")
+DPKG_LOCATION="--DPKG_LOCATION=$(PAL_DIR)/installer/InstallBuilder/tools/bin/dpkg-deb-$(PF_ARCH)"
+else
+DPKG_LOCATION=
+endif
 
 installerOnly: bundle
 
@@ -131,7 +136,7 @@ else
 		--VERSION=$(SCX_BUILDVERSION_MAJOR).$(SCX_BUILDVERSION_MINOR).$(SCX_BUILDVERSION_PATCH) \
 		--RELEASE=$(SCX_BUILDVERSION_BUILDNR) \
 		--ULINUX_POSTFIX=/openssl_0.9.8 $(DISABLE_PORT) \
-		--DPKG_LOCATION=$(SCXPAL_DIR)/installer/InstallBuilder/tools/bin/dpkg-deb-$(PF_ARCH) \
+		$(DPKG_LOCATION) \
 		--DATAFILE_PATH=$(SCX_BRD)/installer/datafiles \
 		--OUTPUTFILE=$(OUTPUT_PACKAGE_PREFIX) \
 		$(DATAFILES) $(DATAFILES_D)
@@ -150,7 +155,7 @@ else
 		--VERSION=$(SCX_BUILDVERSION_MAJOR).$(SCX_BUILDVERSION_MINOR).$(SCX_BUILDVERSION_PATCH) \
 		--RELEASE=$(SCX_BUILDVERSION_BUILDNR) \
 		--ULINUX_POSTFIX=/openssl_1.0.0 $(DISABLE_PORT) \
-		--DPKG_LOCATION=$(SCXPAL_DIR)/installer/InstallBuilder/tools/bin/dpkg-deb-$(PF_ARCH) \
+		$(DPKG_LOCATION) \
 		--DATAFILE_PATH=$(SCX_BRD)/installer/datafiles \
 		--OUTPUTFILE=$(OUTPUT_PACKAGE_PREFIX) \
 		$(DATAFILES) $(DATAFILES_D)


### PR DESCRIPTION
Makefile - Add SHELL=/bin/bash.  Debian variants default to /bin/sh, which breaks brace expansion.

Makefile.kits - Do not set DPKG_LOCATION if /usr/bin/dpkg is present.

@jeffaco 
@niroyb 
