### PR TITLE
Improve Travis Continuous Integration Detection Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # SCXcore [![Build Status](https://travis-ci.org/Microsoft/SCXcore.svg?branch=master)](https://travis-ci.org/Microsoft/SCXcore)
 
 SCXcore is the Operations Manager UNIX/Linux Agent, typically used for
-Operations Manager but also a host of other projects as well.
+Operations Manager, but is also used in a host of other products as
+well.
 
-In sort, SCXcore provides a CIMOM provider, based on [OMI][], to
-return logging and statistical information for a UNIX or Linux
-system. The SCXcore provider runs on AIX 6.1 and later, HP/UX 11.31
-and later, Solaris 5.10 and later, and most versions of Linux as far
-back as RedHat 5.0, SuSE 10.1, and Debian 5.0.
+The SCXcore provides a CIMOM provider, based on [OMI][], to return
+logging and statistical information for a UNIX or Linux system. The
+SCXcore provider runs on AIX 6.1 and later, HP/UX 11.31 and later,
+Solaris 5.10 and later, and most versions of Linux as far back as
+RedHat 5.0, SuSE 10.1, and Debian 5.0.
 
 [OMI]: https://travis-ci.org/Microsoft/omi

--- a/build/Makefile.gcc3
+++ b/build/Makefile.gcc3
@@ -12,6 +12,10 @@
 # Define flags. (These will be submitted to all commands that use the preprocesor)
 DEFINES=-DPF_DISTRO_$(PF_DISTRO) -DPF_MAJOR=$(PF_MAJOR) -DOS_MINOR=$(PF_MINOR) -D$(ARCH) -DPF_WIDTH=$(PF_WIDTH)
 
+ifeq ($(TRAVIS_CI), 1)
+	DEFINES += -DTRAVIS
+endif
+
 ifeq ($(SCX_STACK_ONLY), true)
 	DEFINES += -DSCX_STACK_ONLY
 endif

--- a/build/configure
+++ b/build/configure
@@ -162,6 +162,24 @@ if [ $combined_packages -ne 0 ]; then
     openssl100_libs=`PKG_CONFIG_PATH=$openssl100_libdir/pkgconfig $pkgconfig --libs openssl`
 fi
 
+##==============================================================================
+##
+## running on Travis?
+##
+##==============================================================================
+
+travis_ci=0
+if [ "$TRAVIS" = "true" ]; then
+    echo "Currently running on Travis for Continuous Integration ..."
+    travis_ci=1
+fi
+
+##==============================================================================
+##
+## handle versions and write configuration
+##
+##==============================================================================
+
 # Do we have a version file from the super project? If not, make one
 
 if [ -f ../../scxcore.version ]; then
@@ -193,6 +211,7 @@ OPENSSL098_LIBDIR=$openssl098_libdir
 OPENSSL100_CFLAGS=$openssl100_cflags
 OPENSSL100_LIBS=$openssl100_libs
 OPENSSL100_LIBDIR=$openssl100_libdir
+TRAVIS_CI=$travis_ci
 EOF
 
 # Fix permissions in case they aren't executable - and then configure OMI

--- a/test/code/providers/os_provider/osprovider_test.cpp
+++ b/test/code/providers/os_provider/osprovider_test.cpp
@@ -23,6 +23,12 @@
 
 #include "testutilities.h"
 
+#if defined(TRAVIS)
+const bool s_fTravis = true;
+#else
+const bool s_fTravis = false;
+#endif
+
 using namespace SCXCore;
 using namespace SCXCoreLib;
 using namespace SCXSystemLib;
@@ -115,17 +121,6 @@ public:
 
     void ValidateInstance(const TestableContext &context, std::wstring errMsg)
     {
-        bool fRunningOnTravis = false;
-#if defined(linux)
-        // We make assumptions about our environment, but those don't always hold on Travis
-
-        char *envTravis = getenv("TRAVIS");
-        if (NULL != envTravis && 0 == strncmp(envTravis, "true", 4))
-        {
-            fRunningOnTravis = true;
-        }
-#endif
-
         CPPUNIT_ASSERT_EQUAL_MESSAGE(ERROR_MESSAGE, 1u, context.Size());
         
         const TestableInstance &instance = context[0];
@@ -323,7 +318,7 @@ public:
         // Travis CI systems don't appear to have a pagefile. Lots of RAM, but
         // no pagefile. Test assumed a multi-user system with a pagefile, so
         // ease up on that if we're running on a Travis CI system.
-        if ( ! fRunningOnTravis )
+        if ( ! s_fTravis )
         {
             CPPUNIT_ASSERT(256000 <= ulTotalSwap);
             CPPUNIT_ASSERT(512000 <= ulTotalVM);


### PR DESCRIPTION
Rather than looking up environment variables in code each time we
need to detect travis, #define TRAVIS so consumers can easily
determine if special Travis CI handling is needed.

@Microsoft/ostc-devs 