### PR TITLE
Resolve memory leak in RunAs provider (SCXThread object leaking)

### DIFF
--- a/source/code/providers/SCX_OperatingSystem_Class_Provider.cpp
+++ b/source/code/providers/SCX_OperatingSystem_Class_Provider.cpp
@@ -567,7 +567,7 @@ void SCX_OperatingSystem_Class_Provider::Invoke_ExecuteCommand(
     SCX_PEX_BEGIN
     {
         SCX_OperatingSystem_Command_ThreadParam* params = new SCX_OperatingSystem_Command_ThreadParam(context.context(), in);
-        new SCXCoreLib::SCXThread(Invoke_ExecuteCommand_ThreadBody, params);
+        SCXCoreLib::SCXThread(Invoke_ExecuteCommand_ThreadBody, params);
     }
     SCX_PEX_END( L"SCX_OperatingSystem_Class_Provider::Invoke_ExecuteCommand", log );
 }
@@ -672,7 +672,7 @@ void SCX_OperatingSystem_Class_Provider::Invoke_ExecuteShellCommand(
     SCX_PEX_BEGIN
     {
         SCX_OperatingSystem_ShellCommand_ThreadParam* params = new SCX_OperatingSystem_ShellCommand_ThreadParam(context.context(), in);
-        new SCXCoreLib::SCXThread(Invoke_ExecuteShellCommand_ThreadBody, params);
+        SCXCoreLib::SCXThread(Invoke_ExecuteShellCommand_ThreadBody, params);
     }
     SCX_PEX_END( L"SCX_OperatingSystem_Class_Provider::Invoke_ExecuteShellCommand", SCXCore::g_RunAsProvider.GetLogHandle() );
 }
@@ -789,7 +789,7 @@ void SCX_OperatingSystem_Class_Provider::Invoke_ExecuteScript(
     SCX_PEX_BEGIN
     {
         SCX_OperatingSystem_Script_ThreadParam* params = new SCX_OperatingSystem_Script_ThreadParam(context.context(), in);
-        new SCXCoreLib::SCXThread(Invoke_ExecuteScript_ThreadBody, params);
+        SCXCoreLib::SCXThread(Invoke_ExecuteScript_ThreadBody, params);
     }
     SCX_PEX_END( L"SCX_OperatingSystem_Class_Provider::Invoke_ExecuteScript", log );
 }


### PR DESCRIPTION
Commit hash 0921ef7 (back in 2013) incorporated a memory leak of the
SCXThread object. This was "fixed" in f004d08, which was supposed to
roll back other changes to the SCX_OperatingSystem_Class_Provider.cxx
and then fix the bug.

However, it turns out that the fixes never made it past the rollback.
This commit fixes those leaks for real.

@Microsoft/ostc-devs 

Note: I have some test files that will be checked in tomorrow. I want to get this in for tonight's build.