### PR TITLE
Fix non default config in JBoss 7

### DIFF
--- a/source/code/providers/support/appserver/jbossappserverinstance.cpp
+++ b/source/code/providers/support/appserver/jbossappserverinstance.cpp
@@ -179,8 +179,13 @@ namespace SCXSystemLib
 
         if (config.find(fJBossStandaloneStr) != std::string::npos) 
         {
-            fJBossStandaloneCheck = true;
-            m_config = L"/standalone/configuration/";
+        	fJBossStandaloneCheck = true;
+        	if(config.find(L".xml") != std::string::npos)
+        	{
+        		std::string::size_type loc = config.find(L"standalone/configuration/");
+        		m_jbossStandaloneConfigFile = config.substr(loc);
+        	}
+        	m_config = L"/standalone/configuration/";
         }
         else if (config.find(fJBossDomainStr) != std::string::npos)
         {
@@ -898,8 +903,15 @@ namespace SCXSystemLib
 			const string cHttpName("http");
 			const string cHttpsName("https");
 			const string cPortAttributeName("port");
-
-            filename.Append(L"standalone/configuration/standalone.xml");
+			
+			if(m_jbossStandaloneConfigFile.length() != 0)
+			{
+				filename.Append(m_jbossStandaloneConfigFile);
+			}
+			else
+			{
+				filename.Append(L"standalone/configuration/standalone.xml");
+			}
             try 
             {
                 SCXHandle<istream> mystream = m_deps->OpenXmlPortsFile(filename.Get());

--- a/source/code/providers/support/appserver/jbossappserverinstance.h
+++ b/source/code/providers/support/appserver/jbossappserverinstance.h
@@ -81,6 +81,7 @@ namespace SCXSystemLib
         std::wstring m_serverName;
         std::wstring m_basePath;
         std::wstring m_portsBinding;
+        std::wstring m_jbossStandaloneConfigFile;
 
         SCXCoreLib::SCXHandle<JBossAppServerInstancePALDependencies> m_deps;
     };

--- a/test/code/providers/appserver_provider/appserverenumeration_test.cpp
+++ b/test/code/providers/appserver_provider/appserverenumeration_test.cpp
@@ -251,6 +251,7 @@ class AppServerEnumeration_Test : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( JBoss_Process_Good_Params_3_Running );
     CPPUNIT_TEST( JBoss_Process_Good_Params_22_Running );
     CPPUNIT_TEST( JBoss_Domain_Process_Good_Params );
+    CPPUNIT_TEST( JBoss_Standalone_Non_Default_Config );
     CPPUNIT_TEST( testReadInstancesMethodCalledAtInit );
     CPPUNIT_TEST( testWriteInstancesMethodCalledAtCleanup );
     CPPUNIT_TEST( Tomcat_Process_Good_Params );
@@ -883,6 +884,58 @@ public:
         std::vector<SCXCoreLib::SCXHandle<AppServerInstance> >::iterator it = asEnum.Begin();
         
         CPPUNIT_ASSERT_EQUAL(L"/root/wildfly-8.1.0.CR2/wildfly-8.1.0.CR2/domain/servers/server-one/",(*it)->GetId());
+        
+        asEnum.CleanUp();
+    }
+    
+    void JBoss_Standalone_Non_Default_Config()
+    {
+        SCXCoreLib::SCXHandle<MockAppServerPALDependencies> pal = SCXCoreLib::SCXHandle<MockAppServerPALDependencies>(new MockAppServerPALDependencies());
+        TestSpyAppServerEnumeration asEnum(pal);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 0);
+
+        SCXCoreLib::SCXHandle<MockProcessInstance> inst;
+        
+        inst = pal->CreateProcessInstance(1234, "1234");
+        inst->AddParameter("/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java");
+        inst->AddParameter("-D[Standalone]");
+        inst->AddParameter("-XX:+UseCompressedOops");
+        inst->AddParameter("-verbose:gc");
+        inst->AddParameter("-Xloggc:/konsens/log/rmsvlg/as/4.2.0.2/gc.log");
+        inst->AddParameter("-XX:+PrintGCDetails");
+        inst->AddParameter("-server");
+        inst->AddParameter("-XX:+PrintGCDateStamps");
+        inst->AddParameter("-XX:+UseGCLogFileRotation");
+        inst->AddParameter("-XX:NumberOfGCLogFiles=5");
+        inst->AddParameter("-XX:GCLogFileSize=3M");
+        inst->AddParameter("-XX:-TraceClassUnloading");
+        inst->AddParameter("-Xms2048m");
+        inst->AddParameter("-Xmx2048m");
+        inst->AddParameter("-Dorg.jboss.boot.log.file=/konsens/log/rmsvlg/as/4.2.0.2/server.log");
+        inst->AddParameter("-Dlogging.configuration=file:/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/logging.properties");
+        inst->AddParameter("-jar");
+        inst->AddParameter("/konsens/app/jboss-eap-6.4/jboss-modules.jar ");
+        inst->AddParameter("-mp");
+        inst->AddParameter("/konsens/app/jboss-eap-6.4/modules");
+        inst->AddParameter("-jaxpmodule");
+        inst->AddParameter("javax.xml.jaxp-provider");
+        inst->AddParameter("org.jboss.as.standalone");
+        inst->AddParameter("-Djboss.home.dir=/konsens/app/jboss-eap-6.4");
+        inst->AddParameter("-Djboss.server.base.dir=/konsens/app/rmsvlg/as/4.2.0.2/standalone");
+        inst->AddParameter("-Djboss.server.log.dir=/konsens/log/rmsvlg/as/4.2.0.2");
+        inst->AddParameter("-c");
+        inst->AddParameter("standalone-full.xml");
+        inst->AddParameter("-b");
+        inst->AddParameter("0.0.0.0");
+
+        asEnum.Update(false);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 1);
+        
+        std::vector<SCXCoreLib::SCXHandle<AppServerInstance> >::iterator it = asEnum.Begin();
+        
+        CPPUNIT_ASSERT_EQUAL(L"/konsens/app/jboss-eap-6.4/standalone/configuration/",(*it)->GetId());
         
         asEnum.CleanUp();
     }

--- a/test/code/providers/appserver_provider/jbossappserverinstance_test.cpp
+++ b/test/code/providers/appserver_provider/jbossappserverinstance_test.cpp
@@ -808,6 +808,7 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( testBadVersionXml );
     CPPUNIT_TEST( testBadHttpPortValue );
     CPPUNIT_TEST( testBadPortOffsetValue );
+    CPPUNIT_TEST( testJBoss7WithNonDefaultConfig );
     CPPUNIT_TEST( testPort_XMLSetTo_Junk_CommandLineSetTo_ports01 );
     CPPUNIT_TEST( testPort_XMLSetTo_Port01_CommandLineSetTo_Junk );
     CPPUNIT_TEST( testPort_XMLSetTo_Junk_NoCommandLineBinding );
@@ -1037,6 +1038,34 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
         CPPUNIT_ASSERT_EQUAL(L"8443", asInstance->GetHttpsPort());
         
         CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone.xml", deps->m_xmlPortsFilename);
+    }
+    
+    void testJBoss7WithNonDefaultConfig()
+    {
+        SCXHandle<JBossAppServerInstanceTestPALDependencies> deps(new JBossAppServerInstanceTestPALDependencies());
+        
+        deps->SetVersion5(false);
+        deps->SetIncludeJbossJar(false);
+        deps->SetHttpBinding(false);
+        deps->SetHttpsBinding(false);
+        deps->SetVersion7(true);
+        deps->SetNoVersionFile(true);
+        
+        deps->SetBadPortOffsetValue(false);
+          
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/standalone-full.xml", L"", deps) );
+ 
+        asInstance->Update();
+             
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/", asInstance->GetId());
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/", asInstance->GetDiskPath());
+        CPPUNIT_ASSERT_EQUAL(L"JBoss", asInstance->GetType());
+        CPPUNIT_ASSERT_EQUAL(L"7.0.0.Final",asInstance->GetVersion());
+        CPPUNIT_ASSERT_EQUAL(L"7",asInstance->GetMajorVersion());
+        CPPUNIT_ASSERT_EQUAL(L"8080", asInstance->GetHttpPort());
+        CPPUNIT_ASSERT_EQUAL(L"8443", asInstance->GetHttpsPort());
+        
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone-full.xml", deps->m_xmlPortsFilename);
     }
 
     // Test with XML containing bad port-offset attribute in binding socket


### PR DESCRIPTION
@Microsoft/ostc-devs 

For standalone mode JBoss 7 allows use of some non default config file (standalone-full.xml, standalone-ha.xml etc) . Our current code only considers default stanalone.xml file. Hence when JBoss starts with non default config file it was getting wrongly interpreted as Jboss 4, 5 or 6 which resulted in wrong install path for that JBoss instance.