### PR TITLE
Integrate with new OMI build process (--enable-microsoft)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -16,10 +16,6 @@ PF_POSIX=true
 SCXPAL_DIR := $(shell cd ../../pal; pwd)
 SCXOMI_DIR := $(shell cd ../../omi/Unix; pwd -P)
 
-SCXOMI_DEV_ROOT := $(SCXOMI_DIR)/output
-SCXOMI_INCLUDE := $(SCXOMI_DEV_ROOT)/include
-SCXOMI_LIBS := $(SCXOMI_DEV_ROOT)/lib
-
 include $(SCXPAL_DIR)/build/config.mak
 include $(SCX_BRD)/build/config.mak
 
@@ -33,6 +29,15 @@ include $(SCX_BRD)/build/Makefile.version
 ifndef SCX_BUILDVERSION_STATUS
 $(error "Is Makefile.version missing?  Please re-run configure")
 endif
+
+ifeq ($(COMBINED_PACKAGES),1)
+SCXOMI_DEV_ROOT := $(SCXOMI_DIR)/output_openssl_1.0.0
+else
+SCXOMI_DEV_ROOT := $(SCXOMI_DIR)/output
+endif
+
+SCXOMI_INCLUDE := $(SCXOMI_DEV_ROOT)/include
+SCXOMI_LIBS := $(SCXOMI_DEV_ROOT)/lib
 
 # Figure out if we're doing a production build or a developer build
 

--- a/build/Makefile.components
+++ b/build/Makefile.components
@@ -289,55 +289,8 @@ providers: \
 omi: omi_all
 
 omi_all:
-ifeq ($(COMBINED_PACKAGES),1)
-
-	$(ECHO) "========================= Performing make omi"
-
-	@echo Checking for local installation of OpenSSL version 0.9.8 on build machine ... 
-	@if ! [ -e $(LD_LIBRARY_PATH_OPENSSL098) ]; \
-	then \
-	echo Did not find $(LD_LIBRARY_PATH_OPENSSL098), which is required.; \
-	echo You must install a local copy of OpenSSL version 0.9.8 to build successfully.; \
-	exit 1; \
-	else \
-	echo Found local installation of OpenSSL 0.9.8, proceeding ; \
-	fi
-
-	@echo Checking for local installation of OpenSSL version 1.0.0 on build machine ... 
-	@if ! [ -e $(LD_LIBRARY_PATH_OPENSSL100) ]; \
-	then \
-	echo Did not find $(LD_LIBRARY_PATH_OPENSSL100), which is required.; \
-	echo You must install a local copy of OpenSSL version 1.0.0 to build successfully.; \
-	exit 1; \
-	else \
-	echo Found local installation of OpenSSL version 1.0.0, proceeding ; \
-	fi
-
-	$(ECHO) "========================= Performing make omi (0.9.8)"
-
-	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH_OPENSSL098); \
-	cd $(SCXOMI_DIR); \
-	echo Running: ./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_0.9.8 --opensslcflags="$(OPENSSL098_CFLAGS)" --openssllibs="$(OPENSSL098_LIBS)" --openssllibdir="$(OPENSSL098_LIBDIR)"; \
-	./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_0.9.8 --opensslcflags="$(OPENSSL098_CFLAGS)" --openssllibs="$(OPENSSL098_LIBS)" --openssllibdir="$(OPENSSL098_LIBDIR)"; \
-	$(MAKE) -C $(SCXOMI_DIR) all
-	$(MAKE) -C $(SCXOMI_DIR)/installbuilder OUTPUTDIR="$(SCXOMI_DIR)/output_openssl_0.9.8"
-
-	$(ECHO) "========================= Performing make omi (1.0.0)"
-
-	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH_OPENSSL100); \
-	cd $(SCXOMI_DIR); \
-	echo Running: ./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="$(OPENSSL100_CFLAGS)" --openssllibs="$(OPENSSL100_LIBS)" --openssllibdir="$(OPENSSL100_LIBDIR)"; \
-	./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="$(OPENSSL100_CFLAGS)" --openssllibs="$(OPENSSL100_LIBS)" --openssllibdir="$(OPENSSL100_LIBDIR)"; \
-	$(MAKE) -C $(SCXOMI_DIR) all
-	$(MAKE) -C $(SCXOMI_DIR)/installbuilder OUTPUTDIR="$(SCXOMI_DIR)/output_openssl_1.0.0"
-
-else
-
 	$(ECHO) "========================= Performing make omi"
 	$(MAKE) -C $(SCXOMI_DIR) all
-	$(MAKE) -C $(SCXOMI_DIR)/installbuilder
-
-endif
 
 # Testing tool (needs to be built on each of our platforms)
 $(TARGET_DIR)/testapp :

--- a/build/configure
+++ b/build/configure
@@ -11,7 +11,7 @@ enable_bullseye=""
 combined_packages=0
 
 enable_ulinux_qual=""
-omi_configure_quals="--prefix=/opt/omi --localstatedir=/var/opt/omi --sysconfdir=/etc/opt/omi/conf --certsdir=/etc/opt/omi/ssl"
+omi_configure_quals="--enable-microsoft"
 
 if [ ! -d "$scxpal_dir" ]; then
     echo "PAL directory ($scxpal_dir) does not exist"
@@ -31,6 +31,7 @@ perform_ulinux_build()
     fi
 
     enable_ulinux_qual="--enable-ulinux"
+    omi_configure_quals="$omi_configure_quals $enable_ulinux_qual"
     combined_packages=1
 }
 
@@ -130,7 +131,7 @@ fi
 
 (cd $scxpal_dir/build/ && chmod ug+x ./configure; ./configure $enable_debug $enable_bullseye $enable_ulinux_qual)
 
-omi_configure_quals="--enable-preexec ${enable_debug} ${enable_purify_agent} ${enable_purify_server} ${omi_configure_quals}"
+omi_configure_quals="${enable_debug} ${enable_purify_agent} ${enable_purify_server} ${omi_configure_quals}"
 
 ##==============================================================================
 ##


### PR DESCRIPTION
@Microsoft/ostc-devs @Microsoft/omi-devs 

First stab at OMI building it's own packages. This is tested on Linux and appears to work fine, running a pbuild now for platform breadth.

Note that this shelveset is designed to work in concert with OMI changes as well, review that as well please.
