### PR TITLE
Check that uninstall script exists prior to trying to execute it

### DIFF
--- a/installer/bundle/bundle_skel_PPC-RHEL.sh
+++ b/installer/bundle/bundle_skel_PPC-RHEL.sh
@@ -422,8 +422,9 @@ cd $EXTRACT_DIR
 # Do we need to remove the package?
 if [ "$installMode" = "R" -o "$installMode" = "P" ]
 then
-    /opt/microsoft/scx/bin/uninstall $installMode
-
+    if [ -f /opt/microsoft/scx/bin/uninstall ]; then
+        /opt/microsoft/scx/bin/uninstall $installMode
+    fi
     if [ "$installMode" = "P" ]
     then
         echo "Purging all files in cross-platform agent ..."


### PR DESCRIPTION
Checking for existance of uninstall folder's (/opt/microsoft/scx/bin/uninstall) existance before deleting it.
@jeffaco 