### PR TITLE
Added support in scxsslconfig to generate client auth certificate

### DIFF
--- a/source/code/shared/tools/scx_ssl_config/scxsslcert.h
+++ b/source/code/shared/tools/scx_ssl_config/scxsslcert.h
@@ -87,6 +87,7 @@ class SCXSSLCertificate
     int m_startDays;                     ///< Days to offset valid start time with;
     int m_endDays;                       ///< Days to offset valid end time with;
     int m_bits;                          ///< Number of bits in key
+    bool m_clientCert;                   ///<  Certificate to be used for client authentication
 
 protected:
     SCXCoreLib::SCXFilePath m_KeyPath;   ///< Path to key file;
@@ -97,7 +98,7 @@ protected:
 public:
     SCXSSLCertificate(SCXCoreLib::SCXFilePath keyPath, SCXCoreLib::SCXFilePath certPath,
                       int startDays, int endDays, const std::wstring & hostname,
-                      const std::wstring & domainname, int bits);
+                      const std::wstring & domainname, int bits, bool clientCert = false);
     
     virtual ~SCXSSLCertificate();
 
@@ -146,7 +147,7 @@ class SCXSSLCertificateLocalizedDomain : public SCXSSLCertificate
 public:
     SCXSSLCertificateLocalizedDomain(SCXCoreLib::SCXFilePath keyPath, SCXCoreLib::SCXFilePath certPath,
                               int startDays, int endDays, const std::wstring & hostname,
-                                     const std::wstring & domainname_raw, int bits);
+                                     const std::wstring & domainname_raw, int bits, bool clientCert = false);
 
     using SCXSSLCertificate::Generate; 
     void Generate(std::ostringstream& verbage);


### PR DESCRIPTION
@Microsoft/ostc-devs 

Added new flag -c in scxsslconfig tool to signify client cert generation.
Passing this flag will instruct the tool to add clientAuth EKU to the certificate.
This along with [-g targetpath] option will be used to generate a cert and key that will be used for enhanced log monitoring feature.
Sample command:
scxsslconfig -c -g <Path to cert location>