### PR TITLE
Add logging to show entry/exit into enumeration classes

### DIFF
--- a/source/code/providers/SCX_Agent_Class_Provider.cpp
+++ b/source/code/providers/SCX_Agent_Class_Provider.cpp
@@ -239,6 +239,9 @@ void SCX_Agent_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_MetaProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"MetaProvider EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for MetaProvider class
@@ -248,7 +251,9 @@ void SCX_Agent_Class_Provider::EnumerateInstances(
         EnumerateOneInstance( context, inst, keysOnly );
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_Agent_Class_Provider::EnumerateInstances", SCXCore::g_MetaProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_Agent_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"MetaProvider EnumerateInstances end");
 }
 
 void SCX_Agent_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_Application_Server_Class_Provider.cpp
+++ b/source/code/providers/SCX_Application_Server_Class_Provider.cpp
@@ -112,6 +112,7 @@ void SCX_Application_Server_Class_Provider::EnumerateInstances(
     const MI_Filter* filter)
 {
     SCXLogHandle& log = SCXCore::g_AppServerProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"App Server EnumerateInstances begin");
 
     SCX_PEX_BEGIN
     {
@@ -133,6 +134,8 @@ void SCX_Application_Server_Class_Provider::EnumerateInstances(
         context.Post(MI_RESULT_OK);
     }
     SCX_PEX_END( L"SCX_Application_Server_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"App Server EnumerateInstances end");
 }
 
 void SCX_Application_Server_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_DiskDriveStatisticalInformation_Class_Provider.cpp
+++ b/source/code/providers/SCX_DiskDriveStatisticalInformation_Class_Provider.cpp
@@ -159,6 +159,9 @@ void SCX_DiskDriveStatisticalInformation_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_DiskProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"DiskDriveStat EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for DiskProvider class
@@ -187,8 +190,9 @@ void SCX_DiskDriveStatisticalInformation_Class_Provider::EnumerateInstances(
 
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_DiskDriveStatisticalInformation_Class_Provider::EnumerateInstances",
-                     SCXCore::g_DiskProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_DiskDriveStatisticalInformation_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"DiskDriveStat EnumerateInstances end");
 }
 
 void SCX_DiskDriveStatisticalInformation_Class_Provider::GetInstance(
@@ -226,7 +230,7 @@ void SCX_DiskDriveStatisticalInformation_Class_Provider::GetInstance(
         context.Post(MI_RESULT_OK);
     }
     SCX_PEX_END( L"SCX_DiskDriveStatisticalInformation_Class_Provider::GetInstance",
-                      SCXCore::g_DiskProvider.GetLogHandle() );
+                 SCXCore::g_DiskProvider.GetLogHandle());
 }
 
 void SCX_DiskDriveStatisticalInformation_Class_Provider::CreateInstance(

--- a/source/code/providers/SCX_DiskDrive_Class_Provider.cpp
+++ b/source/code/providers/SCX_DiskDrive_Class_Provider.cpp
@@ -179,6 +179,9 @@ void SCX_DiskDrive_Class_Provider::EnumerateInstances(
         bool keysOnly,
         const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_DiskProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"DiskDrive EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for DiskProvider class
@@ -207,8 +210,9 @@ void SCX_DiskDrive_Class_Provider::EnumerateInstances(
 
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_DiskDrive_Class_Provider::EnumerateInstances",
-                     SCXCore::g_DiskProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_DiskDrive_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"DiskDrive EnumerateInstances end");
 }
 
 void SCX_DiskDrive_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_EthernetPortStatistics_Class_Provider.cpp
+++ b/source/code/providers/SCX_EthernetPortStatistics_Class_Provider.cpp
@@ -115,19 +115,20 @@ void SCX_EthernetPortStatistics_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_NetworkProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"EthernetPortStatistics Provider EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for NetworkProvider class
         SCXCoreLib::SCXThreadLock lock(SCXCoreLib::ThreadLockHandleGet(L"SCXCore::NetworkProvider::Lock"));
     
-        SCX_LOGTRACE(SCXCore::g_NetworkProvider.GetLogHandle(), L"EthernetPortStatistics Provider EnumerateInstances");
-
         // Update network PAL instance. This is both update of number of interfaces and
         // current statistics for each interfaces.
         SCXHandle<SCXCore::NetworkProviderDependencies> deps = SCXCore::g_NetworkProvider.getDependencies();
         deps->UpdateIntf(false);
 
-        SCX_LOGTRACE(SCXCore::g_NetworkProvider.GetLogHandle(), StrAppend(L"Number of interfaces = ", deps->IntfCount()));
+        SCX_LOGTRACE(log, StrAppend(L"Number of interfaces = ", deps->IntfCount()));
 
         for(size_t i = 0; i < deps->IntfCount(); i++)
         {
@@ -138,9 +139,9 @@ void SCX_EthernetPortStatistics_Class_Provider::EnumerateInstances(
 
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_EthernetPortStatistics_Class_Provider::EnumerateInstances",
-                 SCXCore::g_NetworkProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_EthernetPortStatistics_Class_Provider::EnumerateInstances", log );
 
+    SCX_LOGTRACE(log, L"EthernetPortStatistics Provider EnumerateInstances end");
 }
 
 void SCX_EthernetPortStatistics_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_FileSystemStatisticalInformation_Class_Provider.cpp
+++ b/source/code/providers/SCX_FileSystemStatisticalInformation_Class_Provider.cpp
@@ -188,12 +188,15 @@ void SCX_FileSystemStatisticalInformation_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_FileSystemProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"FileSystemStat EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for DiskProvider class
         SCXCoreLib::SCXThreadLock lock(SCXCoreLib::ThreadLockHandleGet(L"SCXCore::DiskProvider::Lock"));
 
-        //  Prepare FIle System Enumeration
+        // Prepare File System Enumeration
         // (Note: Only do full update if we're not enumerating keys)
         SCXHandle<SCXSystemLib::StatisticalLogicalDiskEnumeration> diskEnum = SCXCore::g_FileSystemProvider.getEnumstatisticalLogicalDisks();
         diskEnum->Update(!keysOnly);
@@ -215,8 +218,9 @@ void SCX_FileSystemStatisticalInformation_Class_Provider::EnumerateInstances(
 
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_FileSystemStatisticalInformation_Class_Provider::EnumerateInstances",
-                      SCXCore::g_FileSystemProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_FileSystemStatisticalInformation_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"FileSystemStat EnumerateInstances end");
 }
 
 void SCX_FileSystemStatisticalInformation_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_FileSystem_Class_Provider.cpp
+++ b/source/code/providers/SCX_FileSystem_Class_Provider.cpp
@@ -194,34 +194,39 @@ void SCX_FileSystem_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
-   SCX_PEX_BEGIN
-   {
-       // Global lock for DiskProvider class
-       SCXCoreLib::SCXThreadLock lock(SCXCoreLib::ThreadLockHandleGet(L"SCXCore::DiskProvider::Lock"));
+    SCXLogHandle& log = SCXCore::g_FileSystemProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"FileSystem EnumerateInstances begin");
 
-       // (Note: Only do full update if we're not enumerating keys) 
-       SCXHandle<SCXSystemLib::StaticLogicalDiskEnumeration> staticLogicalDisksEnum = SCXCore::g_FileSystemProvider.getEnumstaticLogicalDisks();
-       staticLogicalDisksEnum->Update(!keysOnly);
+    SCX_PEX_BEGIN
+    {
+        // Global lock for DiskProvider class
+        SCXCoreLib::SCXThreadLock lock(SCXCoreLib::ThreadLockHandleGet(L"SCXCore::DiskProvider::Lock"));
 
-       for(size_t i = 0; i < staticLogicalDisksEnum->Size(); i++) 
-       {
-           SCX_FileSystem_Class inst;
-           SCXHandle<SCXSystemLib::StaticLogicalDiskInstance> diskinst = staticLogicalDisksEnum->GetInstance(i);
-           EnumerateOneInstance(context, inst, keysOnly, diskinst);
-       }
+        // (Note: Only do full update if we're not enumerating keys) 
+        SCXHandle<SCXSystemLib::StaticLogicalDiskEnumeration> staticLogicalDisksEnum = SCXCore::g_FileSystemProvider.getEnumstaticLogicalDisks();
+        staticLogicalDisksEnum->Update(!keysOnly);
 
-       // Enumerate Total instance
-       SCXHandle<SCXSystemLib::StaticLogicalDiskInstance> totalInst = staticLogicalDisksEnum->GetTotalInstance();
-       if (totalInst != NULL)
-       {
-           // There will always be one total instance
-           SCX_FileSystem_Class inst;
-           EnumerateOneInstance(context, inst, keysOnly, totalInst);
-       }
+        for(size_t i = 0; i < staticLogicalDisksEnum->Size(); i++) 
+        {
+            SCX_FileSystem_Class inst;
+            SCXHandle<SCXSystemLib::StaticLogicalDiskInstance> diskinst = staticLogicalDisksEnum->GetInstance(i);
+            EnumerateOneInstance(context, inst, keysOnly, diskinst);
+        }
 
-       context.Post(MI_RESULT_OK);
-   }
-   SCX_PEX_END( L"SCX_FileSystem_Class_Provider::EnumerateInstances", SCXCore::g_FileSystemProvider.GetLogHandle() );
+        // Enumerate Total instance
+        SCXHandle<SCXSystemLib::StaticLogicalDiskInstance> totalInst = staticLogicalDisksEnum->GetTotalInstance();
+        if (totalInst != NULL)
+        {
+            // There will always be one total instance
+            SCX_FileSystem_Class inst;
+            EnumerateOneInstance(context, inst, keysOnly, totalInst);
+        }
+
+        context.Post(MI_RESULT_OK);
+    }
+    SCX_PEX_END( L"SCX_FileSystem_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"FileSystem EnumerateInstances end");
 }
 
 void SCX_FileSystem_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_IPProtocolEndpoint_Class_Provider.cpp
+++ b/source/code/providers/SCX_IPProtocolEndpoint_Class_Provider.cpp
@@ -143,20 +143,20 @@ void SCX_IPProtocolEndpoint_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_NetworkProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"IPProtocolEndpoint Provider EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
-        SCX_LOGTRACE(SCXCore::g_NetworkProvider.GetLogHandle(), L"SCXCore::NetworkProvider::Enumerate entry");
         // Global lock for NetworkProvider class
         SCXCoreLib::SCXThreadLock lock(SCXCoreLib::ThreadLockHandleGet(L"SCXCore::NetworkProvider::Lock"));
  
-        SCX_LOGTRACE(SCXCore::g_NetworkProvider.GetLogHandle(), L"IPProtocolEndpoint Provider EnumerateInstances");
-
         // Update network PAL instance. This is both update of number of interfaces and
         // current statistics for each interfaces.
         SCXHandle<SCXCore::NetworkProviderDependencies> deps = SCXCore::g_NetworkProvider.getDependencies();
         deps->UpdateIntf(false);
 
-        SCX_LOGTRACE(SCXCore::g_NetworkProvider.GetLogHandle(), StrAppend(L"Number of interfaces = ", deps->IntfCount()));
+        SCX_LOGTRACE(log, StrAppend(L"Number of interfaces = ", deps->IntfCount()));
 
         for(size_t i = 0; i < deps->IntfCount(); i++)
         {
@@ -166,7 +166,10 @@ void SCX_IPProtocolEndpoint_Class_Provider::EnumerateInstances(
         }
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_IPProtocolEndpoint_Class_Provider::EnumerateInstances", SCXCore::g_NetworkProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_IPProtocolEndpoint_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"IPProtocolEndpoint Provider EnumerateInstances end");
+
 }
 
 void SCX_IPProtocolEndpoint_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_LANEndpoint_Class_Provider.cpp
+++ b/source/code/providers/SCX_LANEndpoint_Class_Provider.cpp
@@ -114,19 +114,20 @@ void SCX_LANEndpoint_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_NetworkProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"LANEndpoint Provider EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for NetworkProvider class
         SCXCoreLib::SCXThreadLock lock(SCXCoreLib::ThreadLockHandleGet(L"SCXCore::NetworkProvider::Lock"));
-
-        SCX_LOGTRACE(SCXCore::g_NetworkProvider.GetLogHandle(), L"LANEndpoint Provider EnumerateInstances");
 
         // Update network PAL instance. This is both update of number of interfaces and
         // current statistics for each interfaces.
         SCXHandle<SCXCore::NetworkProviderDependencies> deps = SCXCore::g_NetworkProvider.getDependencies();
         deps->UpdateIntf(false);
 
-        SCX_LOGTRACE(SCXCore::g_NetworkProvider.GetLogHandle(), StrAppend(L"Number of interfaces = ", deps->IntfCount()));
+        SCX_LOGTRACE(log, StrAppend(L"Number of interfaces = ", deps->IntfCount()));
 
         for(size_t i = 0; i < deps->IntfCount(); i++)
         {
@@ -136,8 +137,9 @@ void SCX_LANEndpoint_Class_Provider::EnumerateInstances(
         }
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_LANEndpoint_Class_Provider::EnumerateInstances", SCXCore::g_NetworkProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_LANEndpoint_Class_Provider::EnumerateInstances", log );
 
+    SCX_LOGTRACE(log, L"LANEndpoint Provider EnumerateInstances end");
 }
 
 void SCX_LANEndpoint_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_LogFile_Class_Provider.cpp
+++ b/source/code/providers/SCX_LogFile_Class_Provider.cpp
@@ -151,6 +151,7 @@ void SCX_LogFile_Class_Provider::Invoke_GetMatchedRows(
      */
 
     SCXCoreLib::SCXLogHandle log = SCXCore::g_LogFileProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"LogFile Provider Invoke begin");
 
     SCX_PEX_BEGIN
     {
@@ -267,6 +268,8 @@ void SCX_LogFile_Class_Provider::Invoke_GetMatchedRows(
         context.Post(MI_RESULT_OK);
     }
     SCX_PEX_END( L"SCX_LogFile_Class_Provider::Load", log );
+
+    SCX_LOGTRACE(log, L"LogFile Provider Invoke end");
 }
 
 void SCX_LogFile_Class_Provider::Invoke_ResetStateFile(

--- a/source/code/providers/SCX_MemoryStatisticalInformation_Class_Provider.cpp
+++ b/source/code/providers/SCX_MemoryStatisticalInformation_Class_Provider.cpp
@@ -216,6 +216,9 @@ void SCX_MemoryStatisticalInformation_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_MemoryProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"MemoryStat EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for MemoryProvider class
@@ -239,8 +242,9 @@ void SCX_MemoryStatisticalInformation_Class_Provider::EnumerateInstances(
 
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_MemoryStatisticalInformation_Class_Provider::EnumerateInstances",
-                       SCXCore::g_MemoryProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_MemoryStatisticalInformation_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"MemoryStat EnumerateInstances end");
 }
 
 void SCX_MemoryStatisticalInformation_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_OperatingSystem_Class_Provider.cpp
+++ b/source/code/providers/SCX_OperatingSystem_Class_Provider.cpp
@@ -345,6 +345,9 @@ void SCX_OperatingSystem_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_OSProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"OperatingSystem EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         SCXThreadLock lock(ThreadLockHandleGet(L"SCXCore::OSProvider::Lock"));
@@ -359,7 +362,9 @@ void SCX_OperatingSystem_Class_Provider::EnumerateInstances(
         EnumerateOneInstance( context, inst, keysOnly, osEnum->GetTotalInstance(), memEnum->GetTotalInstance() );
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_OperatingSystem_Class_Provider::EnumerateInstances", SCXCore::g_OSProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_OperatingSystem_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"OperatingSystem EnumerateInstances end");
 }
 
 void SCX_OperatingSystem_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_ProcessorStatisticalInformation_Class_Provider.cpp
+++ b/source/code/providers/SCX_ProcessorStatisticalInformation_Class_Provider.cpp
@@ -191,6 +191,9 @@ void SCX_ProcessorStatisticalInformation_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = g_CPUProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"ProcessorStat EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for CPUProvider class
@@ -219,8 +222,9 @@ void SCX_ProcessorStatisticalInformation_Class_Provider::EnumerateInstances(
 
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_ProcessorStatisticalInformation_Class_Provider::EnumerateInstances",
-                     g_CPUProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_ProcessorStatisticalInformation_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"ProcessorStat EnumerateInstances end");
 }
 
 void SCX_ProcessorStatisticalInformation_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_RTProcessorStatisticalInformation_Class_Provider.cpp
+++ b/source/code/providers/SCX_RTProcessorStatisticalInformation_Class_Provider.cpp
@@ -226,6 +226,9 @@ void SCX_RTProcessorStatisticalInformation_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = g_CPUProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"RTProcessorStat EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for CPUProvider class
@@ -254,8 +257,9 @@ void SCX_RTProcessorStatisticalInformation_Class_Provider::EnumerateInstances(
 
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_RTProcessorStatisticalInformation_Class_Provider::EnumerateInstances",
-                     g_CPUProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_RTProcessorStatisticalInformation_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"RTProcessorStat EnumerateInstances end");
 }
 
 void SCX_RTProcessorStatisticalInformation_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_UnixProcessStatisticalInformation_Class_Provider.cpp
+++ b/source/code/providers/SCX_UnixProcessStatisticalInformation_Class_Provider.cpp
@@ -231,6 +231,9 @@ void SCX_UnixProcessStatisticalInformation_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_ProcessProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"UnixProcessStat Provider EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for ProcessProvider class
@@ -249,7 +252,9 @@ void SCX_UnixProcessStatisticalInformation_Class_Provider::EnumerateInstances(
         }
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_UnixProcessStatisticalInformation_Class_Provider::EnumerateInstances", SCXCore::g_ProcessProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_UnixProcessStatisticalInformation_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"UnixProcessStat Provider EnumerateInstances end");
 }
 
 void SCX_UnixProcessStatisticalInformation_Class_Provider::GetInstance(

--- a/source/code/providers/SCX_UnixProcess_Class_Provider.cpp
+++ b/source/code/providers/SCX_UnixProcess_Class_Provider.cpp
@@ -254,16 +254,18 @@ void SCX_UnixProcess_Class_Provider::EnumerateInstances(
     bool keysOnly,
     const MI_Filter* filter)
 {
+    SCXLogHandle& log = SCXCore::g_ProcessProvider.GetLogHandle();
+    SCX_LOGTRACE(log, L"UnixProcess Provider EnumerateInstances begin");
+
     SCX_PEX_BEGIN
     {
         // Global lock for ProcessProvider class
         SCXCoreLib::SCXThreadLock lock(SCXCoreLib::ThreadLockHandleGet(L"SCXCore::ProcessProvider::Lock"));
 
-        SCX_LOGTRACE(SCXCore::g_ProcessProvider.GetLogHandle(), L"Process Provider EnumerateInstances");
         SCXHandle<SCXSystemLib::ProcessEnumeration> processEnum = SCXCore::g_ProcessProvider.GetProcessEnumerator();
         processEnum->Update();
 
-        SCX_LOGTRACE(SCXCore::g_ProcessProvider.GetLogHandle(), StrAppend(L"Number of Processes = ", processEnum->Size()));
+        SCX_LOGTRACE(log, StrAppend(L"Number of Processes = ", processEnum->Size()));
 
         for(size_t i = 0; i < processEnum->Size(); i++)
         {
@@ -272,7 +274,9 @@ void SCX_UnixProcess_Class_Provider::EnumerateInstances(
         }
         context.Post(MI_RESULT_OK);
     }
-    SCX_PEX_END( L"SCX_UnixProcess_Class_Provider::EnumerateInstances", SCXCore::g_ProcessProvider.GetLogHandle() );
+    SCX_PEX_END( L"SCX_UnixProcess_Class_Provider::EnumerateInstances", log );
+
+    SCX_LOGTRACE(log, L"UnixProcess Provider EnumerateInstances end");
 }
 
 void SCX_UnixProcess_Class_Provider::GetInstance(


### PR DESCRIPTION
Add logging to isolate if a class within a process is hanging.

NOTE: One of the routines was reformatted for standard indentation. Add `?w=1` to review line to ignore spacing to avoid flagging these as changes.

@Microsoft/ostc-devs  @johnkord @Microsoft/omi-devs 