### PR TITLE
Pick OMI packages from omi-kits repo

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -15,6 +15,7 @@ PF_POSIX=true
 # Get the root of the SCXPAL directory (and other easy locations)
 SCXPAL_DIR := $(shell cd ../../pal; pwd)
 SCXOMI_DIR := $(shell cd ../../omi/Unix; pwd -P)
+OMIKITS_DIR := $(shell cd ../../omi-kits/release; pwd)
 
 include $(SCXPAL_DIR)/build/config.mak
 include $(SCX_BRD)/build/config.mak

--- a/build/Makefile.kits
+++ b/build/Makefile.kits
@@ -7,6 +7,7 @@
 
 OUTPUT_PACKAGE_PREFIX=
 OUTPUT_PACKAGE_SPECIFICATION=
+IS_OPENSSL_100=$(shell openssl version | grep 1.0 | wc -l)
 
 ifneq ($(COMBINED_PACKAGES),1)
   DATAFILES = Base_SCXCore.data $(PF_DEPENDENT_DATAFILES)
@@ -183,10 +184,38 @@ endif
 
 	# Copy remaining kit files to target directory
 ifneq ($(COMBINED_PACKAGES),1)
-
 	# (Copying for non-combined packages)
-	cp `find $(SCXOMI_DIR)/output -name *.$(PACKAGE_SUFFIX)` $(INTERMEDIATE_DIR)/
-	cp `find $(SCXOMI_DIR)/output -name package_filename` $(INTERMEDIATE_DIR)/omi_package_filename
+	rm -f $(INTERMEDIATE_DIR)/omi-*.$(PACKAGE_SUFFIX)
+  ifeq ($(PF),SunOS)
+	cp `find $(OMIKITS_DIR) -name omi-*solaris.$(PF_MINOR).$(PF_ARCH).pkg.Z` $(INTERMEDIATE_DIR)/
+	cd $(INTERMEDIATE_DIR); uncompress `ls omi-*.Z`
+  endif
+
+  ifeq ($(PF_ARCH),ppc)
+    ifeq ($(PF),AIX)
+	cp `find $(OMIKITS_DIR) -name omi-*aix.$(PF_MAJOR).$(PF_ARCH).lpp` $(INTERMEDIATE_DIR)/
+    else
+	cp `find $(OMIKITS_DIR) -name omi-*rhel.$(PF_MAJOR).$(PF_ARCH).rpm` $(INTERMEDIATE_DIR)/
+    endif
+  endif
+
+  ifeq ($(PF),HPUX)
+	cp `find $(OMIKITS_DIR) -name omi-*hpux.$(PF_MAJOR)*.$(PF_ARCH).depot.Z` $(INTERMEDIATE_DIR)/
+	cd $(INTERMEDIATE_DIR); uncompress `ls omi-*.Z`
+  endif
+
+  # Handle Linux builds when combined packages not enabled
+  ifeq ($(PF),Linux)
+    ifneq ($(PF_ARCH),ppc)
+	# Copy omi kit depending on openssl version
+      ifeq ($(IS_OPENSSL_100),1)
+	cp `find $(OMIKITS_DIR) -name omi-*ssl_100.ulinux.$(PF_ARCH).$(PACKAGE_SUFFIX)` $(INTERMEDIATE_DIR)/
+      else
+	cp `find $(OMIKITS_DIR) -name omi-*ssl_098.ulinux.$(PF_ARCH).$(PACKAGE_SUFFIX)` $(INTERMEDIATE_DIR)/
+      endif
+    endif
+  endif
+	cd $(INTERMEDIATE_DIR); echo `ls omi-*.$(PACKAGE_SUFFIX)` > omi_package_filename
 
   # Handle Redhat on PPC
   ifeq ($(PF_ARCH),ppc)
@@ -213,11 +242,17 @@ else # ifneq ($(COMBINED_PACKAGES),1)
 	# (Copying for combined packages)
         ifeq ($(DISABLE_LISTENER),0)
 	  # Grab the OMI bits
-	  cd $(INTERMEDIATE_DIR); cp $(SCXOMI_DIR)/output_openssl_0.9.8/release/omi-*.{rpm,deb} 098
-	  cd $(INTERMEDIATE_DIR); cp $(SCXOMI_DIR)/output_openssl_1.0.0/release/omi-*.{rpm,deb} 100
+	  cd $(INTERMEDIATE_DIR); cp $(OMIKITS_DIR)/omi-*ssl_098*$(PF_ARCH).{rpm,deb} 098
+	  cd $(INTERMEDIATE_DIR); cp $(OMIKITS_DIR)/omi-*ssl_100*$(PF_ARCH).{rpm,deb} 100
+          # Remove ssl_098 and ssl_100 from omi filename
+	  cd $(INTERMEDIATE_DIR)/098; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_098\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/098; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_098\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/100; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_100\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/100; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_100\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/100; echo `ls omi-*.deb` > omi_package_filename
         endif
 	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 098/*.{rpm,deb} 100/*.{rpm,deb} $(OSS_KITS)
-	../installer/bundle/create_bundle.sh $(DISTRO_TYPE) $(INTERMEDIATE_DIR) $(OUTPUT_PACKAGE_PREFIX).tar $(OUTPUT_PACKAGE_PREFIX) `cat $(SCXOMI_DIR)/output_openssl_1.0.0/release/package_filename` $(DISABLE_LISTENER)
+	../installer/bundle/create_bundle.sh $(DISTRO_TYPE) $(INTERMEDIATE_DIR) $(OUTPUT_PACKAGE_PREFIX).tar $(OUTPUT_PACKAGE_PREFIX) `cat $(INTERMEDIATE_DIR)/100/omi_package_filename` $(DISABLE_LISTENER)
 	cp $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).sh $(TARGET_DIR)
 
 endif # ifneq ($(COMBINED_PACKAGES),1)

--- a/installer/bundle/bundle_skel_AIX.sh
+++ b/installer/bundle/bundle_skel_AIX.sh
@@ -49,6 +49,7 @@ usage()
     echo "  --restart-deps         Reconfigure and restart dependent service"
     echo "  --source-references    Show source code reference hashes."
     echo "  --upgrade              Upgrade the package in the system."
+    echo "  --enable-opsmgr        Enable port 1270 for usage with opsmgr."
     echo "  --version              Version of this shell bundle."
     echo "  --debug                use shell debug mode."
     echo "  -? | --help            shows this usage text."
@@ -210,6 +211,13 @@ do
         --upgrade)
             verifyNoInstallationOption
             installMode=U
+            shift 1
+            ;;
+
+        --enable-opsmgr)
+            if [ ! -f /etc/scxagent-enable-port ]; then
+                touch /etc/scxagent-enable-port
+            fi
             shift 1
             ;;
 

--- a/installer/bundle/bundle_skel_HPUX.sh
+++ b/installer/bundle/bundle_skel_HPUX.sh
@@ -50,6 +50,7 @@ usage()
     echo "  --restart-deps         Reconfigure and restart dependent service"
     echo "  --source-references    Show source code reference hashes."
     echo "  --upgrade              Upgrade the package in the system."
+    echo "  --enable-opsmgr        Enable port 1270 for usage with opsmgr."
     echo "  --version              Version of this shell bundle."
     echo "  --debug                use shell debug mode."
     echo "  -? | --help            shows this usage text."
@@ -212,6 +213,13 @@ do
         --upgrade)
             verifyNoInstallationOption
             installMode=U
+            shift 1
+            ;;
+
+        --enable-opsmgr)
+            if [ ! -f /etc/scxagent-enable-port ]; then
+                touch /etc/scxagent-enable-port
+            fi
             shift 1
             ;;
 

--- a/installer/bundle/bundle_skel_PPC-RHEL.sh
+++ b/installer/bundle/bundle_skel_PPC-RHEL.sh
@@ -55,6 +55,7 @@ usage()
     echo "  --restart-deps         Reconfigure and restart dependent service"
     echo "  --source-references    Show source code reference hashes."
     echo "  --upgrade              Upgrade the package in the system."
+    echo "  --enable-opsmgr        Enable port 1270 for usage with opsmgr."
     echo "  --version              Version of this shell bundle."
     echo "  --version-check        Check versions already installed to see if upgradable"
     echo "                         (Linux platforms only)."
@@ -356,6 +357,13 @@ do
         --upgrade)
             verifyNoInstallationOption
             installMode=U
+            shift 1
+            ;;
+
+        --enable-opsmgr)
+            if [ ! -f /etc/scxagent-enable-port ]; then
+                touch /etc/scxagent-enable-port
+            fi
             shift 1
             ;;
 

--- a/installer/bundle/bundle_skel_SunOS.sh
+++ b/installer/bundle/bundle_skel_SunOS.sh
@@ -50,6 +50,7 @@ usage()
     echo "  --restart-deps         Reconfigure and restart dependent service"
     echo "  --source-references    Show source code reference hashes."
     echo "  --upgrade              Upgrade the package in the system."
+    echo "  --enable-opsmgr        Enable port 1270 for usage with opsmgr."
     echo "  --version              Version of this shell bundle."
     echo "  --debug                use shell debug mode."
     echo "  -? | --help            shows this usage text."
@@ -248,6 +249,13 @@ do
         --upgrade)
             verifyNoInstallationOption
             installMode=U
+            shift 1
+            ;;
+
+        --enable-opsmgr)
+            if [ ! -f /etc/scxagent-enable-port ]; then
+                touch /etc/scxagent-enable-port
+            fi
             shift 1
             ;;
 

--- a/installer/datafiles/Base_SCXCore.data
+++ b/installer/datafiles/Base_SCXCore.data
@@ -207,15 +207,13 @@ ConfigureRunAs() {
 HandleConfigFiles() {
     rm -f /etc/opt/microsoft/scx/conf/cimserver_current.conf* /etc/opt/microsoft/scx/conf/cimserver_planned.conf* /etc/opt/microsoft/scx/conf/omiserver.conf*
 
-#if DISABLE_PORT != true
-    # File /etc/scxagent-disable-port forces port 1270 to not be listened for
-    if [ ! -f /etc/scxagent-disable-port ]; then
+    # File /etc/scxagent-enable-port opens port 1270 for usage with opsmgr
+    if [ -f /etc/scxagent-enable-port ]; then
         # Add port 1270 to the list of ports that OMI will listen on
         /opt/omi/bin/omiconfigeditor httpsport -a 1270 < /etc/opt/omi/conf/omiserver.conf > /etc/opt/omi/conf/omiserver.conf_temp
         mv /etc/opt/omi/conf/omiserver.conf_temp /etc/opt/omi/conf/omiserver.conf
     fi
-#endif
-    rm -f /etc/scxagent-disable-port
+    rm -f /etc/scxagent-enable-port
 }
 
 GenerateCertificate() {


### PR DESCRIPTION
@Microsoft/ostc-devs 
@lagalbra

scx will no longer build omi packages. Instead it will
take the omi packages from the omi-kits repo where omi
team will check in latest certified omi packages for all
platforms.