### PR TITLE
Fix Omiserver is still running under "/opt/microsoft/scx/bin/" after upgrade OM agent from 2012 to 2016

### DIFF
--- a/installer/bundle/bundle_skel_AIX.sh
+++ b/installer/bundle/bundle_skel_AIX.sh
@@ -106,7 +106,7 @@ verifyNoInstallationOption()
 
 # $1 - The name of the package to check as to whether it's installed
 check_if_pkg_is_installed() {
-    lslpp $1 2> /dev/null 1> /dev/null
+    lslpp -L $1.rte 2> /dev/null 1> /dev/null
     return $?
 }
 
@@ -348,6 +348,11 @@ case "$installMode" in
             # the same version (or less) than the one currently installed.
             OMI_EXIT_STATUS=0
         else
+            # If omi is not installed and scx is installed the installed agent is 2012, in that case stoppping the service before updating
+            check_if_pkg_is_installed scx
+            if [ $? -eq 0 ]; then
+                /opt/microsoft/scx/bin/tools/scxadmin -stop
+            fi
             pkg_add $OMI_PKG omi
             OMI_EXIT_STATUS=$?
         fi


### PR DESCRIPTION
Issue : After upgrading the OM agent from 2012 to 2016 on AIX platform, the Omiserver is still running under "/opt/microsoft/scx/bin/" where as it should be running under "/opt/omi/bin/"

Analysis : On the 2012 OM agent we do not have omi.rte and hence when we check if the omi.rte is already installed, the check fails and omi (2016) is installed, but it does not kill the omiserver process running from "/opt/microsoft/scx/bin/"

Fix : We should stop the 2012 agent (scx.rte) before upgrading to 2016.

Note:
Tried analyzing to place the fix to other appropriate place, but do not see any other place in the code where this can be handled. eg DataFiles 

@ostc-devs