### PR TITLE
Fix IsStillInstalled check for websphere 8.5.x

### DIFF
--- a/source/code/providers/support/appserver/websphereappserverinstance.cpp
+++ b/source/code/providers/support/appserver/websphereappserverinstance.cpp
@@ -360,11 +360,15 @@ namespace SCXSystemLib
                 
         if (SCXDirectory::Exists(profileDiskPath))
         {
+            // Atleast on Websphere 8.5 wsBundleMetadata is a directory.
+            // Hence adding check for presence of the directory along with the file.
             SCXCoreLib::SCXFilePath serverDiskPath(m_diskPath);
             serverDiskPath.AppendDirectory(L"configuration");
+            SCXCoreLib::SCXFilePath metadataDiskPath(serverDiskPath);
             serverDiskPath.Append(L"wsBundleMetadata");
+            metadataDiskPath.AppendDirectory(L"wsBundleMetadata");
                         
-            if (SCXFile::Exists(serverDiskPath.Get()))
+            if (SCXFile::Exists(serverDiskPath.Get()) || SCXDirectory::Exists(metadataDiskPath))
             {
                 return true;
             }


### PR DESCRIPTION
@Microsoft/ostc-devs 

To check whether a websphere is still installed, presence
of file wsBundleMetadata is checked. Atleast on websphere
8.5.x wsBundleMetadata is a directory.
Updated the method to check for the presence of directory.
Also did not remove the file check to avoid any backward
compatibility issues.