### PR TITLE
Add force option in scx uninstall script

### DIFF
--- a/installer/bundle/bundle_skel_Linux.sh
+++ b/installer/bundle/bundle_skel_Linux.sh
@@ -330,20 +330,18 @@ shouldInstall_scx()
 
 remove_and_install()
 {
-    check_if_pkg_is_installed apache-cimprov
-    if [ $? -eq 0 ]; then
-        pkg_rm apache-cimprov
-    fi
-    check_if_pkg_is_installed mysql-cimprov
-    if [ $? -eq 0 ]; then
-        pkg_rm mysql-cimprov
-    fi
-    check_if_pkg_is_installed scx
-    if [ $? -eq 0 ]; then
+    if [ -f /opt/microsoft/scx/bin/uninstall ]; then
+        /opt/microsoft/scx/bin/uninstall R force
+    else
+        check_if_pkg_is_installed apache-cimprov
+        if [ $? -eq 0 ]; then
+            pkg_rm apache-cimprov
+        fi
+        check_if_pkg_is_installed mysql-cimprov
+        if [ $? -eq 0 ]; then
+            pkg_rm mysql-cimprov
+        fi
         pkg_rm scx force
-    fi
-    check_if_pkg_is_installed omi
-    if [ $? -eq 0 ]; then
         pkg_rm omi force
     fi
     pkg_add $OMI_PKG omi

--- a/installer/conf/uninstall
+++ b/installer/conf/uninstall
@@ -5,6 +5,11 @@ if [ -n "$1" ]; then
     uninstallMode=$1
 fi
 
+if [ "$2" = "force" ]; then
+    dpkgForce="--force-all"
+    rpmForce="--nodeps"
+fi
+
 PATH=/usr/bin:/usr/sbin:/bin:/sbin
 umask 022
 
@@ -45,22 +50,22 @@ pkg_rm() {
                         if [ "$uninstallMode" = "P" ]; then
                             dpkg --purge $1 # 1> /dev/null 2> /dev/null
                         else
-                            dpkg --remove $1 # 1> /dev/null 2> /dev/null
+                            dpkg --remove $dpkgForce $1 # 1> /dev/null 2> /dev/null
                         fi
                     else
-                        rpm --erase $1 # 1> /dev/null 2> /dev/null
+                        rpm --erase $rpmForce $1 # 1> /dev/null 2> /dev/null
                     fi
                     ;;
 		
                 REDHAT|SUSE)
-                    rpm --erase $1 # 1> /dev/null 2> /dev/null
+                    rpm --erase $rpmForce $1 # 1> /dev/null 2> /dev/null
                     ;;
 
                 UBUNTU)
                     if [ "$uninstallMode" = "P" ]; then
                         dpkg --purge $1 # 1> /dev/null 2> /dev/null
                     else
-                        dpkg --remove $1 # 1> /dev/null 2> /dev/null
+                        dpkg --remove $dpkgForce $1 # 1> /dev/null 2> /dev/null
                     fi
                     ;;
 
@@ -107,6 +112,10 @@ service_action_delay()
 
 
 stop_omiserver() {
+    if [ -f /opt/omi/bin/service_control ]; then
+        /opt/omi/bin/service_control stop
+        return $?
+    fi
     if [ -f /var/opt/omi/run/omiserver.pid ]; then
         case "$PF" in
             AIX)
@@ -165,6 +174,10 @@ stop_omiserver() {
 
 
 start_omiserver() {
+    if [ -f /opt/omi/bin/service_control ]; then
+        /opt/omi/bin/service_control start
+        return $?
+    fi
     case "$PF" in
         AIX)
             startsrc -s omiserverd -e "LD_LIBRARY_PATH=$OMI_HOME/lib"


### PR DESCRIPTION
@Microsoft/ostc-devs 
@lagalbra

Uninstall script should be used remove packages
during upgrade failure recovery. Since scx and
omi have to be forcibly removed, uninstall script
is updated to accept force parameter.
Also if uninstall script is not present then install
check will not be performed before removing the scx
and omi packages.