### PR TITLE
Fixing the issue when omi user profile does not exist on system

### DIFF
--- a/source/code/shared/tools/scx_ssl_config/scx_ssl_config.cpp
+++ b/source/code/shared/tools/scx_ssl_config/scx_ssl_config.cpp
@@ -473,10 +473,8 @@ static int DoGenerate(const wstring & targetPath, int startDays, int endDays,
         } 
         else if(errno !=0 && errno !=ENOENT && errno !=ESRCH) {
             const char* isTestEnv = getenv("SCX_TESTRUN_ACTIVE");
-            if(isTestEnv)
-                wcout << "getpwnam() failed to fetch the record for user name \"omi\"." << "It has failed with error no "<< errno <<"."<<endl;
-            else
-                throw SCXCoreLib::SCXErrnoUserException(L"getpwnam", L"omi", errno, SCXSRCLOCATION);
+            if(!isTestEnv)
+                throw SCXErrnoUserNameException(L"getpwnam", L"omi", errno, SCXSRCLOCATION);
         }
     }
     catch(const SCXCoreLib::SCXException & e)

--- a/source/code/shared/tools/scx_ssl_config/scx_ssl_config.cpp
+++ b/source/code/shared/tools/scx_ssl_config/scx_ssl_config.cpp
@@ -471,8 +471,12 @@ static int DoGenerate(const wstring & targetPath, int startDays, int endDays,
                 throw SCXCoreLib::SCXErrnoFileException(L"chown", keyPath.Get(), errno, SCXSRCLOCATION);
             }
         } 
-        else if (errno != 0) {
-           throw SCXCoreLib::SCXErrnoException(L"getpwnam", errno, SCXSRCLOCATION);
+        else if(errno !=0 && errno !=ENOENT && errno !=ESRCH) {
+            const char* isTestEnv = getenv("SCX_TESTRUN_ACTIVE");
+            if(isTestEnv)
+                wcout << "getpwnam() failed to fetch the record for user name \"omi\"." << "It has failed with error no "<< errno <<"."<<endl;
+            else
+                throw SCXCoreLib::SCXErrnoUserException(L"getpwnam", L"omi", errno, SCXSRCLOCATION);
         }
     }
     catch(const SCXCoreLib::SCXException & e)

--- a/source/code/shared/tools/scx_ssl_config/scxsslcert.h
+++ b/source/code/shared/tools/scx_ssl_config/scxsslcert.h
@@ -183,6 +183,46 @@ private:
     friend class ScxSSLCertTest;
 };
 
+/*----------------------------------------------------------------------------*/
+/**
+   Specific errno exception for username related errors (see SCXErrnoException).
+*/
+class SCXErrnoUserNameException : public SCXCoreLib::SCXErrnoException
+{
+public:
+    /*----------------------------------------------------------------------------*/
+    /**
+       Ctor
+       \param[in] fkncall Function call for user-related operation
+       \param[in] user    username parameter causing internal error
+       \param[in] errno_  System error code with local interpretation
+       \param[in] l       Source code location object
+    */
+
+    SCXErrnoUserNameException(std::wstring fkncall, std::wstring user, int errno_, const SCXCoreLib::SCXCodeLocation& l)
+        : SCXErrnoException(fkncall, errno_, l), m_fkncall(fkncall), m_user(user)
+    { };
+
+    std::wstring What() const {
+        std::wostringstream txt;
+        txt << L"Calling " << m_fkncall << "() with user name parameter\"" << m_user
+            << "\", returned an error with errno = " << m_errno << L" (" << m_errtext.c_str() << L")";
+        return txt.str();
+    }
+
+    /** Returns function call for the user operation falure
+        \returns user-operation in std::wstring encoding
+    */
+    std::wstring GetFnkcall() const { return m_fkncall; }
+
+    std::wstring GetUser() const { return m_user; }
+protected:
+    //! Text of user-related function call
+    std::wstring m_fkncall;
+    std::wstring m_user;
+};
+
+
 #endif /* SCXSSLCERT_H */
 
 /*--------------------------E-N-D---O-F---F-I-L-E----------------------------*/


### PR DESCRIPTION
This change set includes
1. Different way to handle the error cases in pbuild and product deployment environment.
2. Calling new exception handler to print the exception appropriately.
eg.
"Calling getpwnam() with user name parameter "omi", returned an error with errno = 1(Operation not permitted )"


