### PR TITLE
Support multiple JBoss standalone instances with same home directory

### DIFF
--- a/source/code/providers/support/appserver/jbossappserverinstance.h
+++ b/source/code/providers/support/appserver/jbossappserverinstance.h
@@ -58,13 +58,15 @@ namespace SCXSystemLib
             std::wstring id, 
             std::wstring config,
             std::wstring portsBinding,
-            SCXCoreLib::SCXHandle<JBossAppServerInstancePALDependencies> deps = SCXCoreLib::SCXHandle<JBossAppServerInstancePALDependencies>(new JBossAppServerInstancePALDependencies()));
+            SCXCoreLib::SCXHandle<JBossAppServerInstancePALDependencies> deps = SCXCoreLib::SCXHandle<JBossAppServerInstancePALDependencies>(new JBossAppServerInstancePALDependencies()),
+            std::wstring deployment = L"");
         JBossAppServerInstance(
             std::wstring diskPath,
             SCXCoreLib::SCXHandle<JBossAppServerInstancePALDependencies> deps = SCXCoreLib::SCXHandle<JBossAppServerInstancePALDependencies>(new JBossAppServerInstancePALDependencies()));
         virtual ~JBossAppServerInstance();
 
         virtual void Update();
+        virtual bool IsStillInstalled();
 
     private:
         void UpdateVersion();

--- a/test/code/providers/appserver_provider/appserverenumeration_test.cpp
+++ b/test/code/providers/appserver_provider/appserverenumeration_test.cpp
@@ -251,7 +251,10 @@ class AppServerEnumeration_Test : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( JBoss_Process_Good_Params_3_Running );
     CPPUNIT_TEST( JBoss_Process_Good_Params_22_Running );
     CPPUNIT_TEST( JBoss_Domain_Process_Good_Params );
+    CPPUNIT_TEST( JBoss_Standalone_Config_Dir );
     CPPUNIT_TEST( JBoss_Standalone_Non_Default_Config );
+    CPPUNIT_TEST( JBoss_Standalone_CmdLine_Port_Offset );
+    CPPUNIT_TEST( JBoss_Standalone_no_standalone_base_dir );
     CPPUNIT_TEST( testReadInstancesMethodCalledAtInit );
     CPPUNIT_TEST( testWriteInstancesMethodCalledAtCleanup );
     CPPUNIT_TEST( Tomcat_Process_Good_Params );
@@ -311,6 +314,7 @@ public:
     /**************************************************************************************/
     void JBoss_Process_Good_Params_space()
     {
+    try {
         SCXCoreLib::SCXHandle<MockAppServerPALDependencies> pal = SCXCoreLib::SCXHandle<MockAppServerPALDependencies>(new MockAppServerPALDependencies());
         TestSpyAppServerEnumeration asEnum(pal);
 
@@ -345,6 +349,10 @@ public:
         CPPUNIT_ASSERT(L"/opt/jboss-6.0/server/default/" == (*it)->GetId());
         
         asEnum.CleanUp();
+    }
+    catch(const std::exception & ex) {
+        std::cout<<ex.what()<<std::endl;
+    }
     }
     
     /**************************************************************************************/
@@ -888,6 +896,57 @@ public:
         asEnum.CleanUp();
     }
     
+    void JBoss_Standalone_Config_Dir()
+    {
+        SCXCoreLib::SCXHandle<MockAppServerPALDependencies> pal = SCXCoreLib::SCXHandle<MockAppServerPALDependencies>(new MockAppServerPALDependencies());
+        TestSpyAppServerEnumeration asEnum(pal);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 0);
+
+        SCXCoreLib::SCXHandle<MockProcessInstance> inst;
+        
+        inst = pal->CreateProcessInstance(1234, "1234");
+        inst->AddParameter("/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java");
+        inst->AddParameter("org.jboss.as.standalone");
+        inst->AddParameter("-Djboss.home.dir=/konsens/app/jboss-eap-6.4");
+        inst->AddParameter("-Djboss.server.base.dir=/konsens/app/rmsvlg/as/4.2.0.2/standalone");
+        inst->AddParameter("-Djboss.server.log.dir=/konsens/log/rmsvlg/as/4.2.0.2");
+        inst->AddParameter("-Dlogging.configuration=file:/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/logging.properties");
+        inst->AddParameter("-b");
+        inst->AddParameter("0.0.0.0");
+
+        inst = pal->CreateProcessInstance(12345, "12345");
+        inst->AddParameter("/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java");
+        inst->AddParameter("org.jboss.as.standalone");
+        inst->AddParameter("-Djboss.home.dir=/konsens/app/jboss-eap-6.4");
+        inst->AddParameter("-Djboss.server.base.dir=/konsens/app/rmsvlg/as/4.2.0.2/standalone");
+        inst->AddParameter("-Djboss.server.config.dir=/konsens/app/rmsvlg/as/4.2.0.0/standalone/configuration");
+        inst->AddParameter("-Djboss.server.log.dir=/konsens/log/rmsvlg/as/4.2.0.2");
+        inst->AddParameter("-Dlogging.configuration=file:/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/logging.properties");
+        inst->AddParameter("-b");
+        inst->AddParameter("0.0.0.0");
+
+        inst = pal->CreateProcessInstance(1234, "1234");
+        inst->AddParameter("/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java");
+        inst->AddParameter("org.jboss.as.standalone");
+        inst->AddParameter("-Djboss.home.dir=/konsens/app/jboss-eap-6.4");
+        inst->AddParameter("-Djboss.server.log.dir=/konsens/log/rmsvlg/as/4.2.0.2");
+        inst->AddParameter("-Dlogging.configuration=file:/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/logging.properties");
+        inst->AddParameter("-b");
+        inst->AddParameter("0.0.0.0");
+
+        asEnum.Update(false);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 3);
+
+        std::vector<SCXCoreLib::SCXHandle<AppServerInstance> >::iterator it = asEnum.Begin();
+        CPPUNIT_ASSERT(L"/konsens/app/jboss-eap-6.4/standalone/configuration/" == (*it)->GetId());
+        CPPUNIT_ASSERT(L"/konsens/app/rmsvlg/as/4.2.0.0/standalone/configuration/" == (*(++it))->GetId());
+        CPPUNIT_ASSERT(L"/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/" == (*(++it))->GetId());
+        
+        asEnum.CleanUp();
+    }
+
     void JBoss_Standalone_Non_Default_Config()
     {
         SCXCoreLib::SCXHandle<MockAppServerPALDependencies> pal = SCXCoreLib::SCXHandle<MockAppServerPALDependencies>(new MockAppServerPALDependencies());
@@ -935,7 +994,81 @@ public:
         
         std::vector<SCXCoreLib::SCXHandle<AppServerInstance> >::iterator it = asEnum.Begin();
         
-        CPPUNIT_ASSERT_EQUAL(L"/konsens/app/jboss-eap-6.4/standalone/configuration/",(*it)->GetId());
+        CPPUNIT_ASSERT_EQUAL(L"/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/standalone-full.xml",(*it)->GetId());
+        
+        asEnum.CleanUp();
+    }
+
+    void JBoss_Standalone_CmdLine_Port_Offset()
+    {
+        SCXCoreLib::SCXHandle<MockAppServerPALDependencies> pal = SCXCoreLib::SCXHandle<MockAppServerPALDependencies>(new MockAppServerPALDependencies());
+        TestSpyAppServerEnumeration asEnum(pal);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 0);
+
+        SCXCoreLib::SCXHandle<MockProcessInstance> inst;
+        
+        inst = pal->CreateProcessInstance(1234, "1234");
+        inst->AddParameter("/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java");
+        inst->AddParameter("org.jboss.as.standalone");
+        inst->AddParameter("-Djboss.home.dir=/konsens/app/jboss-eap-6.4");
+        inst->AddParameter("-Djboss.server.base.dir=/konsens/app/rmsvlg/as/4.2.0.2/standalone");
+        inst->AddParameter("-Djboss.server.log.dir=/konsens/log/rmsvlg/as/4.2.0.2");
+        inst->AddParameter("-Dlogging.configuration=file:/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/logging.properties");
+        inst->AddParameter("-Djboss.socket.binding.port-offset=1000");
+        inst->AddParameter("-b");
+        inst->AddParameter("0.0.0.0");
+
+        inst = pal->CreateProcessInstance(12345, "12345");
+        inst->AddParameter("/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java");
+        inst->AddParameter("org.jboss.as.standalone");
+        inst->AddParameter("-Djboss.home.dir=/konsens/app/jboss-eap-6.4");
+        inst->AddParameter("-Djboss.server.base.dir=/konsens/app/rmsvlg/as/4.2.0.2/standalone");
+        inst->AddParameter("-Djboss.server.config.dir=/konsens/app/rmsvlg/as/4.2.0.0/standalone/configuration");
+        inst->AddParameter("-Djboss.server.log.dir=/konsens/log/rmsvlg/as/4.2.0.2");
+        inst->AddParameter("-Dlogging.configuration=file:/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/logging.properties");
+        inst->AddParameter("-Djboss.socket.binding.port-offset=2000");
+        inst->AddParameter("-c");
+        inst->AddParameter("standalone-full.xml");
+        inst->AddParameter("-b");
+        inst->AddParameter("0.0.0.0");
+
+        asEnum.Update(false);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 2);
+
+        std::vector<SCXCoreLib::SCXHandle<AppServerInstance> >::iterator it = asEnum.Begin();
+        CPPUNIT_ASSERT(L"/konsens/app/rmsvlg/as/4.2.0.0/standalone/configuration/standalone-full.xml:2000" == (*it)->GetId());
+        CPPUNIT_ASSERT(L"/konsens/app/rmsvlg/as/4.2.0.2/standalone/configuration/:1000" == (*(++it))->GetId());
+        
+        asEnum.CleanUp();
+    }
+
+    void JBoss_Standalone_no_standalone_base_dir()
+    {
+        SCXCoreLib::SCXHandle<MockAppServerPALDependencies> pal = SCXCoreLib::SCXHandle<MockAppServerPALDependencies>(new MockAppServerPALDependencies());
+        TestSpyAppServerEnumeration asEnum(pal);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 0);
+
+        SCXCoreLib::SCXHandle<MockProcessInstance> inst;
+        
+        inst = pal->CreateProcessInstance(1234, "1234");
+        inst->AddParameter("/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java");
+        inst->AddParameter("org.jboss.as.standalone");
+        inst->AddParameter("-Djboss.home.dir=/konsens/app/jboss-eap-6.4");
+        inst->AddParameter("-Djboss.server.base.dir=/konsens/app/rmsvlg/as/4.2.0.2/instance0");
+        inst->AddParameter("-Djboss.server.log.dir=/konsens/log/rmsvlg/as/4.2.0.2");
+        inst->AddParameter("-Dlogging.configuration=file:/konsens/app/rmsvlg/as/4.2.0.2/instance0/configuration/logging.properties");
+        inst->AddParameter("-b");
+        inst->AddParameter("0.0.0.0");
+
+        asEnum.Update(false);
+
+        CPPUNIT_ASSERT(asEnum.Size() == 1);
+
+        std::vector<SCXCoreLib::SCXHandle<AppServerInstance> >::iterator it = asEnum.Begin();
+        CPPUNIT_ASSERT(L"/konsens/app/rmsvlg/as/4.2.0.2/instance0/configuration/" == (*it)->GetId());
         
         asEnum.CleanUp();
     }

--- a/test/code/providers/appserver_provider/jbossappserverinstance_test.cpp
+++ b/test/code/providers/appserver_provider/jbossappserverinstance_test.cpp
@@ -809,6 +809,8 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST( testBadHttpPortValue );
     CPPUNIT_TEST( testBadPortOffsetValue );
     CPPUNIT_TEST( testJBoss7WithNonDefaultConfig );
+    CPPUNIT_TEST( testJBoss7WithCmdLinePortOffset );
+    CPPUNIT_TEST( testJBoss7NoStandaloneConfigDir );
     CPPUNIT_TEST( testPort_XMLSetTo_Junk_CommandLineSetTo_ports01 );
     CPPUNIT_TEST( testPort_XMLSetTo_Port01_CommandLineSetTo_Junk );
     CPPUNIT_TEST( testPort_XMLSetTo_Junk_NoCommandLineBinding );
@@ -847,7 +849,7 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
         deps->SetNoVersionFile(true);
         deps->SetHasEnterpriseVersionFile(true);
         deps->SetBadHttpPortValue(true);
-        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/logging.properties", L"", deps) );
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/", L"", deps) );
  
         asInstance->Update();
 
@@ -965,7 +967,7 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
         deps->SetNoVersionFile(true);
         deps->SetHasBadJboss7VersionFile(true);
         deps->SetBadHttpPortValue(true);
-        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/logging.properties", L"", deps) );
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/", L"", deps) );
  
         asInstance->Update();
 
@@ -994,7 +996,7 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
         deps->SetNoVersionFile(true);
         
         deps->SetBadHttpPortValue(true);
-        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/logging.properties", L"", deps) );
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/", L"", deps) );
  
         asInstance->Update();
           
@@ -1024,7 +1026,7 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
         
         deps->SetBadPortOffsetValue(true);
           
-        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/logging.properties", L"", deps) );
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/", L"", deps) );
  
         asInstance->Update();
              
@@ -1057,8 +1059,8 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
  
         asInstance->Update();
              
-        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/", asInstance->GetId());
-        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/", asInstance->GetDiskPath());
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone-full.xml", asInstance->GetId());
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone-full.xml", asInstance->GetDiskPath());
         CPPUNIT_ASSERT_EQUAL(L"JBoss", asInstance->GetType());
         CPPUNIT_ASSERT_EQUAL(L"7.0.0.Final",asInstance->GetVersion());
         CPPUNIT_ASSERT_EQUAL(L"7",asInstance->GetMajorVersion());
@@ -1066,6 +1068,62 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
         CPPUNIT_ASSERT_EQUAL(L"8443", asInstance->GetHttpsPort());
         
         CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone-full.xml", deps->m_xmlPortsFilename);
+    }
+
+    void testJBoss7WithCmdLinePortOffset()
+    {
+        SCXHandle<JBossAppServerInstanceTestPALDependencies> deps(new JBossAppServerInstanceTestPALDependencies());
+        
+        deps->SetVersion5(false);
+        deps->SetIncludeJbossJar(false);
+        deps->SetHttpBinding(false);
+        deps->SetHttpsBinding(false);
+        deps->SetVersion7(true);
+        deps->SetNoVersionFile(true);
+        
+        deps->SetBadPortOffsetValue(false);
+          
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/standalone-full.xml", L"1000", deps) );
+ 
+        asInstance->Update();
+             
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone-full.xml:1000", asInstance->GetId());
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone-full.xml:1000", asInstance->GetDiskPath());
+        CPPUNIT_ASSERT_EQUAL(L"JBoss", asInstance->GetType());
+        CPPUNIT_ASSERT_EQUAL(L"7.0.0.Final",asInstance->GetVersion());
+        CPPUNIT_ASSERT_EQUAL(L"7",asInstance->GetMajorVersion());
+        CPPUNIT_ASSERT_EQUAL(L"9080", asInstance->GetHttpPort());
+        CPPUNIT_ASSERT_EQUAL(L"9443", asInstance->GetHttpsPort());
+        
+        CPPUNIT_ASSERT_EQUAL( L"id/standalone/configuration/standalone-full.xml", deps->m_xmlPortsFilename);
+    }
+
+    void testJBoss7NoStandaloneConfigDir()
+    {
+        SCXHandle<JBossAppServerInstanceTestPALDependencies> deps(new JBossAppServerInstanceTestPALDependencies());
+        
+        deps->SetVersion5(false);
+        deps->SetIncludeJbossJar(false);
+        deps->SetHttpBinding(false);
+        deps->SetHttpsBinding(false);
+        deps->SetVersion7(true);
+        deps->SetNoVersionFile(true);
+        
+        deps->SetBadPortOffsetValue(false);
+          
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/instance0/configuration/", L"", deps, L"standalone") );
+ 
+        asInstance->Update();
+             
+        CPPUNIT_ASSERT_EQUAL( L"id/instance0/configuration/", asInstance->GetId());
+        CPPUNIT_ASSERT_EQUAL( L"id/instance0/configuration/", asInstance->GetDiskPath());
+        CPPUNIT_ASSERT_EQUAL(L"JBoss", asInstance->GetType());
+        CPPUNIT_ASSERT_EQUAL(L"7.0.0.Final",asInstance->GetVersion());
+        CPPUNIT_ASSERT_EQUAL(L"7",asInstance->GetMajorVersion());
+        CPPUNIT_ASSERT_EQUAL(L"8080", asInstance->GetHttpPort());
+        CPPUNIT_ASSERT_EQUAL(L"8443", asInstance->GetHttpsPort());
+        
+        CPPUNIT_ASSERT_EQUAL( L"id/instance0/configuration/standalone.xml", deps->m_xmlPortsFilename);
     }
 
     // Test with XML containing bad port-offset attribute in binding socket
@@ -1081,7 +1139,7 @@ class JBossAppServerInstance_Test : public CPPUNIT_NS::TestFixture
         deps->SetNoVersionFile(true);
 
         deps->SetBadPortOffsetValueWithSocket(true);
-        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/logging.properties", L"", deps) );
+        SCXHandle<JBossAppServerInstance> asInstance( new JBossAppServerInstance(L"id/", L"id/standalone/configuration/", L"", deps) );
  
         asInstance->Update();
              


### PR DESCRIPTION
JBoss standalone mode allows multiple instances to run using same
Jboss home dir. To support this Key and Diskpath is set to the
complete configuration file used for the instance.

Also same configuration file can be used for different instances
by giving diffrenet port offset. The code is updated to check
for port offset in command line parameters. If present it will
be appended to Key and Diskpath to uniquely identify the instance.

JBoss does not mandate that standalone should be a directory in
configuration path. Updated the agent to pass detected deployment type
from appserver enumeration to JBoss instance. Value of deployment type
will be used to determine if it is an JBoss standalone instance.