### PR TITLE
Create selinux module for logrotate feature on debian platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
       - libcurl4-openssl-dev
       - rpm
       - time
+      - selinux-policy-dev
 
 before_install:
   - date

--- a/build/Makefile.kits
+++ b/build/Makefile.kits
@@ -360,7 +360,7 @@ GetLinuxOS:
 endif
 
 # Build SELinux policy modules for scxagent-logrotate
-ifeq ($(PF)$(PF_ARCH)$(wildcard /usr/bin/dpkg-deb),$(filter $(PF)$(PF_ARCH)$(wildcard /usr/bin/dpkg-deb), Linuxx64 Linuxx86))
+ifeq ($(PF)$(PF_ARCH),$(filter $(PF)$(PF_ARCH), Linuxx64 Linuxx86))
     sepolicy: $(SEPOLICY_DIR)/scxagent-logrotate.pp $(SEPOLICY_DIR_EL6)/scxagent-logrotate.pp
 else
     sepolicy:

--- a/installer/conf/logrotate.conf
+++ b/installer/conf/logrotate.conf
@@ -2,6 +2,7 @@
     rotate 5
     missingok
     notifempty
+    nodateext
     compress
     size 50M
     copytruncate

--- a/installer/datafiles/Linux.data
+++ b/installer/datafiles/Linux.data
@@ -3,6 +3,7 @@ PF:	      'Linux'
 OMI_SERVICE:  '/opt/omi/bin/service_control'
 OMI_CONF_EDITOR: '/opt/omi/bin/omiconfigeditor'
 OMI_CONF_FILE: '/etc/opt/omi/conf/omiserver.conf'
+SEPKG_DIR_SCXAGENT: '/usr/share/selinux/packages/scxagent-logrotate'
 
 PFDISTRO: 'ULINUX'
 PFMAJOR: '1'
@@ -12,16 +13,53 @@ PFMINOR: '0'
 ULINUX
 
 %Files
-/opt/microsoft/scx/bin/tools/GetLinuxOS.sh;                             intermediate/${{BUILD_CONFIGURATION}}/GetLinuxOS.sh;                    755; root; root
-/etc/opt/microsoft/scx/conf/scx-release;                                installer/conf/scx-release;                                       644; root; ${{ROOT_GROUP_NAME}}; conffile
-/etc/opt/microsoft/scx/conf/logrotate.conf;                             installer/conf/logrotate.conf;                                    644; root; ${{ROOT_GROUP_NAME}}; conffile
+${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.fc;                          installer/selinux/scxagent-logrotate.fc;                                 644; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.te;                          installer/selinux/scxagent-logrotate.te;                                 644; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.el6.te;                      installer/selinux/scxagent-logrotate.el6.te;                             644; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.pp;                          intermediate/${{BUILD_CONFIGURATION}}/selinux/scxagent-logrotate.pp;     755; root; ${{ROOT_GROUP_NAME}};
+${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.el6.pp;                      intermediate/${{BUILD_CONFIGURATION}}/selinux.el6/scxagent-logrotate.pp; 755; root; ${{ROOT_GROUP_NAME}};
+/opt/microsoft/scx/bin/tools/GetLinuxOS.sh;                             intermediate/${{BUILD_CONFIGURATION}}/GetLinuxOS.sh;                     755; root; root
+/etc/opt/microsoft/scx/conf/scx-release;                                installer/conf/scx-release;                                              644; root; ${{ROOT_GROUP_NAME}}; conffile
+/etc/opt/microsoft/scx/conf/logrotate.conf;                             installer/conf/logrotate.conf;                                           644; root; ${{ROOT_GROUP_NAME}}; conffile
 
 %Links
 /etc/logrotate.d/scxagent;                                           /etc/opt/microsoft/scx/conf/logrotate.conf;                          644; root; ${{ROOT_GROUP_NAME}}
 
 %Directories
-/etc/logrotate.d;                                                                                                                         755; root; ${{ROOT_GROUP_NAME}}; sysdir
+/usr/share/selinux/packages;                                                                                                                     755; root; ${{ROOT_GROUP_NAME}}; sysdir
+/usr/share/selinux/packages/scxagent-logrotate;                                                                                                  755; root; ${{ROOT_GROUP_NAME}}; sysdir
+/etc/logrotate.d;                                                                                                                                755; root; ${{ROOT_GROUP_NAME}}; sysdir
 
+
+%Postinstall_1500
+if [ -e /usr/sbin/semodule ]; then
+    echo "System appears to have SELinux installed, attempting to install selinux policy module for logrotate"
+    echo "  Trying ${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.pp ..."
+    sestatus=`sestatus|grep status|awk '{print $3}'`
+    if [ -e /usr/bin/dpkg-deb -a "$sestatus" = "disabled" ]; then
+        echo "WARNING: scxagent-logrotate selinux policy module has not yet installed due to selinux is disabled."
+        echo "When enabling selinux, load scxagent-logrotate module manually with following commands for logrotate feature to work properly for scx logs."
+        echo "/usr/sbin/semodule -i $SEPKG_DIR_SCXAGENT/scxagent-logrotate.pp >/dev/null 2>&1"
+        echo "/sbin/restorecon -R /var/opt/microsoft/scx/log > /dev/null 2>&1"
+    else
+        /usr/sbin/semodule -i ${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.pp >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "ERROR: scxagent-logrotate selinux policy module versions could not be installed"
+            exit 0
+        fi
+
+        # Labeling scxagent log files
+        /sbin/restorecon -R /var/opt/microsoft/scx/log > /dev/null 2>&1
+    fi
+fi
+
+%Postuninstall_1500
+if [ -e /usr/sbin/semodule ]; then
+    if [ ! -z "$(/usr/sbin/semodule -l | grep scxagent-logrotate)" ]; then
+        echo "Removing selinux policy module for scxagent-logrotate ..."
+        /usr/sbin/semodule -r scxagent-logrotate
+    fi
+fi
 
 %Preinstall_50
 # VerifySSLVersion

--- a/installer/datafiles/Linux_RPM.data
+++ b/installer/datafiles/Linux_RPM.data
@@ -1,19 +1,6 @@
 %Variables
 PERFORMING_UPGRADE_NOT: '[ "$1" -ne 1 ]'
 PACKAGE_TYPE: 'RPM'
-SEPKG_DIR_SCXAGENT: '/usr/share/selinux/packages/scxagent-logrotate'
-
-%Files
-${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.fc;                       installer/selinux/scxagent-logrotate.fc;                                 644; root; ${{ROOT_GROUP_NAME}};
-${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.te;                       installer/selinux/scxagent-logrotate.te;                                 644; root; ${{ROOT_GROUP_NAME}};
-${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.el6.te;                   installer/selinux/scxagent-logrotate.el6.te;                             644; root; ${{ROOT_GROUP_NAME}};
-${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.pp;                       intermediate/${{BUILD_CONFIGURATION}}/selinux/scxagent-logrotate.pp;     755; root; ${{ROOT_GROUP_NAME}};
-${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.el6.pp;                   intermediate/${{BUILD_CONFIGURATION}}/selinux.el6/scxagent-logrotate.pp; 755; root; ${{ROOT_GROUP_NAME}};
-
-%Directories
-/usr/share/selinux/packages;                                                                                                                  755; root; ${{ROOT_GROUP_NAME}}; sysdir
-/usr/share/selinux/packages/scxagent-logrotate;                                                                                               755; root; ${{ROOT_GROUP_NAME}}; sysdir
-
 
 %Dependencies
 omi >= 1.0.8-6
@@ -30,25 +17,3 @@ if [ $1 -eq 0 ]; then
 
 %Preuninstall_5000
 fi  ## if [ $1 -eq 0 ]
-
-%Postinstall_1500
-if [ -e /usr/sbin/semodule ]; then
-    echo "System appears to have SELinux installed, attempting to install selinux policy module for logrotate"
-    echo "  Trying ${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.pp ..."
-    /usr/sbin/semodule -i ${{SEPKG_DIR_SCXAGENT}}/scxagent-logrotate.pp >/dev/null 2>&1
-    if [ $? -ne 0 ]; then
-        echo "ERROR: scxagent-logrotate selinux policy module versions could not be installed"
-        exit 0
-    fi
-
-    # Labeling scxagent log files
-    /sbin/restorecon -R /var/opt/microsoft/scx/log > /dev/null 2>&1
-fi
-
-%Postuninstall_1500
-if [ -e /usr/sbin/semodule ]; then
-    if [ ! -z "$(/usr/sbin/semodule -l | grep scxagent-logrotate)" ]; then
-        echo "Removing selinux policy module for scxagent-logrotate ..."
-        /usr/sbin/semodule -r scxagent-logrotate
-    fi
-fi


### PR DESCRIPTION
Previously logrotate sepolicy module was created only for RPM based platforms so that logrotate utility has sufficient security context to rotate scx.log. Same is needed for deb based platform as well.