### PR TITLE
Pick OMI packages from omi-kits repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - git submodule foreach git checkout master
   -
   - # The 2016-URNext branch uses specific versions of subcomponents
-  - (cd omi; git checkout v1.0.8-6)
+  - (cd omi; git checkout stable)
   - (cd pal; git checkout 2016-URNext)
   -
   - # Patch in the version of SCXcore that Travis gave to us

--- a/build/Makefile
+++ b/build/Makefile
@@ -15,10 +15,7 @@ PF_POSIX=true
 # Get the root of the SCXPAL directory (and other easy locations)
 SCXPAL_DIR := $(shell cd ../../pal; pwd)
 SCXOMI_DIR := $(shell cd ../../omi/Unix; pwd -P)
-
-SCXOMI_DEV_ROOT := $(SCXOMI_DIR)/output
-SCXOMI_INCLUDE := $(SCXOMI_DEV_ROOT)/include
-SCXOMI_LIBS := $(SCXOMI_DEV_ROOT)/lib
+OMIKITS_DIR := $(shell cd ../../omi-kits/release; pwd)
 
 include $(SCXPAL_DIR)/build/config.mak
 include $(SCX_BRD)/build/config.mak
@@ -33,6 +30,15 @@ include $(SCX_BRD)/build/Makefile.version
 ifndef SCX_BUILDVERSION_STATUS
 $(error "Is Makefile.version missing?  Please re-run configure")
 endif
+
+ifeq ($(COMBINED_PACKAGES),1)
+SCXOMI_DEV_ROOT := $(SCXOMI_DIR)/output_openssl_1.0.0
+else
+SCXOMI_DEV_ROOT := $(SCXOMI_DIR)/output
+endif
+
+SCXOMI_INCLUDE := $(SCXOMI_DEV_ROOT)/include
+SCXOMI_LIBS := $(SCXOMI_DEV_ROOT)/lib
 
 # Figure out if we're doing a production build or a developer build
 

--- a/build/Makefile.components
+++ b/build/Makefile.components
@@ -289,55 +289,8 @@ providers: \
 omi: omi_all
 
 omi_all:
-ifeq ($(COMBINED_PACKAGES),1)
-
-	$(ECHO) "========================= Performing make omi"
-
-	@echo Checking for local installation of OpenSSL version 0.9.8 on build machine ... 
-	@if ! [ -e $(LD_LIBRARY_PATH_OPENSSL098) ]; \
-	then \
-	echo Did not find $(LD_LIBRARY_PATH_OPENSSL098), which is required.; \
-	echo You must install a local copy of OpenSSL version 0.9.8 to build successfully.; \
-	exit 1; \
-	else \
-	echo Found local installation of OpenSSL 0.9.8, proceeding ; \
-	fi
-
-	@echo Checking for local installation of OpenSSL version 1.0.0 on build machine ... 
-	@if ! [ -e $(LD_LIBRARY_PATH_OPENSSL100) ]; \
-	then \
-	echo Did not find $(LD_LIBRARY_PATH_OPENSSL100), which is required.; \
-	echo You must install a local copy of OpenSSL version 1.0.0 to build successfully.; \
-	exit 1; \
-	else \
-	echo Found local installation of OpenSSL version 1.0.0, proceeding ; \
-	fi
-
-	$(ECHO) "========================= Performing make omi (0.9.8)"
-
-	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH_OPENSSL098); \
-	cd $(SCXOMI_DIR); \
-	echo Running: ./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_0.9.8 --opensslcflags="$(OPENSSL098_CFLAGS)" --openssllibs="$(OPENSSL098_LIBS)" --openssllibdir="$(OPENSSL098_LIBDIR)"; \
-	./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_0.9.8 --opensslcflags="$(OPENSSL098_CFLAGS)" --openssllibs="$(OPENSSL098_LIBS)" --openssllibdir="$(OPENSSL098_LIBDIR)"; \
-	$(MAKE) -C $(SCXOMI_DIR) all
-	$(MAKE) -C $(SCXOMI_DIR)/installbuilder OUTPUTDIR="$(SCXOMI_DIR)/output_openssl_0.9.8"
-
-	$(ECHO) "========================= Performing make omi (1.0.0)"
-
-	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH_OPENSSL100); \
-	cd $(SCXOMI_DIR); \
-	echo Running: ./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="$(OPENSSL100_CFLAGS)" --openssllibs="$(OPENSSL100_LIBS)" --openssllibdir="$(OPENSSL100_LIBDIR)"; \
-	./configure $(OMI_CONFIGURE_QUALS) --outputdirname=output_openssl_1.0.0 --opensslcflags="$(OPENSSL100_CFLAGS)" --openssllibs="$(OPENSSL100_LIBS)" --openssllibdir="$(OPENSSL100_LIBDIR)"; \
-	$(MAKE) -C $(SCXOMI_DIR) all
-	$(MAKE) -C $(SCXOMI_DIR)/installbuilder OUTPUTDIR="$(SCXOMI_DIR)/output_openssl_1.0.0"
-
-else
-
 	$(ECHO) "========================= Performing make omi"
 	$(MAKE) -C $(SCXOMI_DIR) all
-	$(MAKE) -C $(SCXOMI_DIR)/installbuilder
-
-endif
 
 # Testing tool (needs to be built on each of our platforms)
 $(TARGET_DIR)/testapp :

--- a/build/Makefile.kits
+++ b/build/Makefile.kits
@@ -7,6 +7,7 @@
 
 OUTPUT_PACKAGE_PREFIX=
 OUTPUT_PACKAGE_SPECIFICATION=
+IS_OPENSSL_100=$(shell openssl version | grep 1.0 | wc -l)
 
 ifneq ($(COMBINED_PACKAGES),1)
   DATAFILES = Base_SCXCore.data $(PF_DEPENDENT_DATAFILES)
@@ -185,8 +186,37 @@ endif
 ifneq ($(COMBINED_PACKAGES),1)
 
 	# (Copying for non-combined packages)
-	cp `find $(SCXOMI_DIR)/output -name *.$(PACKAGE_SUFFIX)` $(INTERMEDIATE_DIR)/
-	cp `find $(SCXOMI_DIR)/output -name package_filename` $(INTERMEDIATE_DIR)/omi_package_filename
+	rm -f $(INTERMEDIATE_DIR)/omi-*.$(PACKAGE_SUFFIX)
+  ifeq ($(PF),SunOS)
+	cp `find $(OMIKITS_DIR) -name omi-*solaris.$(PF_MINOR).$(PF_ARCH).pkg.Z` $(INTERMEDIATE_DIR)/
+	cd $(INTERMEDIATE_DIR); uncompress `ls omi-*.Z`
+  endif
+
+  ifeq ($(PF_ARCH),ppc)
+    ifeq ($(PF),AIX)
+	cp `find $(OMIKITS_DIR) -name omi-*aix.$(PF_MAJOR).$(PF_ARCH).lpp` $(INTERMEDIATE_DIR)/
+    else
+	cp `find $(OMIKITS_DIR) -name omi-*rhel.$(PF_MAJOR).$(PF_ARCH).rpm` $(INTERMEDIATE_DIR)/
+    endif
+  endif
+
+  ifeq ($(PF),HPUX)
+	cp `find $(OMIKITS_DIR) -name omi-*hpux.$(PF_MAJOR)*.$(PF_ARCH).depot.Z` $(INTERMEDIATE_DIR)/
+	cd $(INTERMEDIATE_DIR); uncompress `ls omi-*.Z`
+  endif
+
+  # Handle Linux builds when combined packages not enabled
+  ifeq ($(PF),Linux)
+    ifneq ($(PF_ARCH),ppc)
+	# Copy omi kit depending on openssl version
+      ifeq ($(IS_OPENSSL_100),1)
+	cp `find $(OMIKITS_DIR) -name omi-*ssl_100.ulinux.$(PF_ARCH).$(PACKAGE_SUFFIX)` $(INTERMEDIATE_DIR)/
+      else
+	cp `find $(OMIKITS_DIR) -name omi-*ssl_098.ulinux.$(PF_ARCH).$(PACKAGE_SUFFIX)` $(INTERMEDIATE_DIR)/
+      endif
+    endif
+  endif
+	cd $(INTERMEDIATE_DIR); echo `ls omi-*.$(PACKAGE_SUFFIX)` > omi_package_filename
 
   # Handle Redhat on PPC
   ifeq ($(PF_ARCH),ppc)
@@ -213,11 +243,17 @@ else # ifneq ($(COMBINED_PACKAGES),1)
 	# (Copying for combined packages)
         ifeq ($(DISABLE_LISTENER),0)
 	  # Grab the OMI bits
-	  cd $(INTERMEDIATE_DIR); cp $(SCXOMI_DIR)/output_openssl_0.9.8/release/omi-*.{rpm,deb} 098
-	  cd $(INTERMEDIATE_DIR); cp $(SCXOMI_DIR)/output_openssl_1.0.0/release/omi-*.{rpm,deb} 100
+	  cd $(INTERMEDIATE_DIR); cp $(OMIKITS_DIR)/omi-*ssl_098*$(PF_ARCH).{rpm,deb} 098
+	  cd $(INTERMEDIATE_DIR); cp $(OMIKITS_DIR)/omi-*ssl_100*$(PF_ARCH).{rpm,deb} 100
+          # Remove ssl_098 and ssl_100 from omi filename
+	  cd $(INTERMEDIATE_DIR)/098; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_098\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/098; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_098\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/100; mv omi-*.deb `ls omi-*.deb | sed "s/\.ssl_100\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/100; mv omi-*.rpm `ls omi-*.rpm | sed "s/\.ssl_100\./\./g"`
+	  cd $(INTERMEDIATE_DIR)/100; echo `ls omi-*.deb` > omi_package_filename
         endif
 	cd $(INTERMEDIATE_DIR); tar cvf $(OUTPUT_PACKAGE_PREFIX).tar 098/*.{rpm,deb} 100/*.{rpm,deb} $(OSS_KITS)
-	../installer/bundle/create_bundle.sh $(DISTRO_TYPE) $(INTERMEDIATE_DIR) $(OUTPUT_PACKAGE_PREFIX).tar $(OUTPUT_PACKAGE_PREFIX) `cat $(SCXOMI_DIR)/output_openssl_1.0.0/release/package_filename` $(DISABLE_LISTENER)
+	../installer/bundle/create_bundle.sh $(DISTRO_TYPE) $(INTERMEDIATE_DIR) $(OUTPUT_PACKAGE_PREFIX).tar $(OUTPUT_PACKAGE_PREFIX) `cat $(INTERMEDIATE_DIR)/100/omi_package_filename` $(DISABLE_LISTENER)
 	cp $(INTERMEDIATE_DIR)/$(OUTPUT_PACKAGE_PREFIX).sh $(TARGET_DIR)
 
 endif # ifneq ($(COMBINED_PACKAGES),1)

--- a/build/configure
+++ b/build/configure
@@ -11,7 +11,7 @@ enable_bullseye=""
 combined_packages=0
 
 enable_ulinux_qual=""
-omi_configure_quals="--prefix=/opt/omi --localstatedir=/var/opt/omi --sysconfdir=/etc/opt/omi/conf --certsdir=/etc/opt/omi/ssl"
+omi_configure_quals="--enable-microsoft"
 
 if [ ! -d "$scxpal_dir" ]; then
     echo "PAL directory ($scxpal_dir) does not exist"
@@ -31,6 +31,7 @@ perform_ulinux_build()
     fi
 
     enable_ulinux_qual="--enable-ulinux"
+    omi_configure_quals="$omi_configure_quals $enable_ulinux_qual"
     combined_packages=1
 }
 
@@ -130,7 +131,7 @@ fi
 
 (cd $scxpal_dir/build/ && chmod ug+x ./configure; ./configure $enable_debug $enable_bullseye $enable_ulinux_qual)
 
-omi_configure_quals="--enable-preexec ${enable_debug} ${enable_purify_agent} ${enable_purify_server} ${omi_configure_quals}"
+omi_configure_quals="${enable_debug} ${enable_purify_agent} ${enable_purify_server} ${omi_configure_quals}"
 
 ##==============================================================================
 ##

--- a/source/code/shared/tools/scx_ssl_config/scxsslcert.h
+++ b/source/code/shared/tools/scx_ssl_config/scxsslcert.h
@@ -182,6 +182,45 @@ private:
     friend class ScxSSLCertTest;
 };
 
+/*----------------------------------------------------------------------------*/
+/**
+   Specific errno exception for username related errors (see SCXErrnoException).
+*/
+class SCXErrnoUserNameException : public SCXCoreLib::SCXErrnoException
+{
+public:
+    /*----------------------------------------------------------------------------*/
+    /**
+       Ctor
+       \param[in] fkncall Function call for user-related operation
+       \param[in] user    username parameter causing internal error
+       \param[in] errno_  System error code with local interpretation
+       \param[in] l       Source code location object
+    */
+
+    SCXErrnoUserNameException(std::wstring fkncall, std::wstring user, int errno_, const SCXCoreLib::SCXCodeLocation& l)
+        : SCXErrnoException(fkncall, errno_, l), m_fkncall(fkncall), m_user(user)
+    { };
+
+    std::wstring What() const {
+        std::wostringstream txt;
+        txt << L"Calling " << m_fkncall << "() with user name parameter\"" << m_user
+            << "\", returned an error with errno = " << m_errno << L" (" << m_errtext.c_str() << L")";
+        return txt.str();
+    }
+
+    /** Returns function call for the user operation falure
+        \returns user-operation in std::wstring encoding
+    */
+    std::wstring GetFnkcall() const { return m_fkncall; }
+
+    std::wstring GetUser() const { return m_user; }
+protected:
+    //! Text of user-related function call
+    std::wstring m_fkncall;
+    std::wstring m_user;
+};
+
 #endif /* SCXSSLCERT_H */
 
 /*--------------------------E-N-D---O-F---F-I-L-E----------------------------*/

--- a/test/code/shared/tools/scx_ssl_config/scxsslcert_test.cpp
+++ b/test/code/shared/tools/scx_ssl_config/scxsslcert_test.cpp
@@ -351,10 +351,12 @@ public:
             SCXCoreLib::SelfDeletingFilePath sdCertPath(cert.m_CertPath.Get());
             SCXCoreLib::SelfDeletingFilePath sdKeyPath(cert.m_KeyPath.Get());
 
+#if !defined(sun)
             //xn--bcher-kva.com is what bücher.com should be in punycode
             CPPUNIT_ASSERT_MESSAGE("Punycode function produced incorrect output", 0 == cert.m_domainname.compare(L"xn--bcher-kva.com"));
-            CPPUNIT_ASSERT_MESSAGE("Output certificate file not found", SCXCoreLib::SCXFile::Exists(cert.m_CertPath));
             CPPUNIT_ASSERT_MESSAGE("Certificate mismatch or corruption", CheckCertificate(cert.m_CertPath.Get(), std::string("xn--bcher-kva"), hostname));
+#endif
+            CPPUNIT_ASSERT_MESSAGE("Output certificate file not found", SCXCoreLib::SCXFile::Exists(cert.m_CertPath));
             CPPUNIT_ASSERT_MESSAGE("Output key file not found", SCXCoreLib::SCXFile::Exists(cert.m_KeyPath));
 
             cout << debugChatter.str();


### PR DESCRIPTION
scx will no longer build omi packages. Instead it will
take the omi packages from the omi-kits repo where omi
team will check in latest certified omi packages for all
platforms.