### PR TITLE
Update error codes returned by scx deb/rpm packages.

### DIFF
--- a/installer/datafiles/Base_SCXCore.data
+++ b/installer/datafiles/Base_SCXCore.data
@@ -217,7 +217,7 @@ HandleConfigFiles() {
 }
 
 GenerateCertificate() {
-    if [ ! -f /etc/opt/omi/ssl/.omi_cert_marker ]; then
+    if [ -d ${{OMI_SSL_DIR}} -a  ! -f /etc/opt/omi/ssl/.omi_cert_marker ]; then
 	# No OMI cert marker.  This means that OM has installed certificates to this folder, or there's data corruption.
 	return 0
     fi
@@ -254,7 +254,7 @@ GenerateCertificate() {
 	    if [ -f ${{OMI_SSL_DIR}}/omi.pem_temp ]; then
 		mv -f ${{OMI_SSL_DIR}}/omi.pem_temp ${{OMI_SSL_DIR}}/omi.pem
 	    fi
-            exit 1
+            exit 21
 	else
 	    # Certificate generated successfully.  Remove /etc/opt/omi/ssl/.omi_cert_marker to signify that we have overwritten omi's cert
 	    rm -f /etc/opt/omi/ssl/.omi_cert_marker
@@ -262,7 +262,7 @@ GenerateCertificate() {
         fi
     else
         # ${{OMI_SSL_DIR}} : directory does not exist
-        exit 1
+        exit 22
     fi
 }
 

--- a/installer/datafiles/Linux.data
+++ b/installer/datafiles/Linux.data
@@ -23,14 +23,14 @@ if [ `uname -m` != "x86_64" ];then
     if [ $? -ne 0 ]; then
         echo 'Unsupported OpenSSL version - must be either 0.9.8* or 1.0.*.'
         echo 'Installation cannot proceed.'
-        exit 1
+        exit 60
     fi
 else
     openssl version | awk '{print $2}' | grep -Eq '^0.9.8|^1.0.|^1.1'
     if [ $? -ne 0 ]; then
         echo 'Unsupported OpenSSL version - must be either 0.9.8* or 1.0.*|^1.1.*.'
         echo 'Installation cannot proceed.'
-        exit 1
+        exit 60
     fi
 fi
 


### PR DESCRIPTION
omsagent requires different error codes for possible
failure conditions that can happen during scx deb/rpm
package installation.
As of now scx returns error code 1 for failure condition
it detects while running the control scripts.
Updated the control scripts to return different error codes
for possible failure scenarios.